### PR TITLE
Fixed JSON payload for transferring existing calls

### DIFF
--- a/src/Voice/Client.php
+++ b/src/Voice/Client.php
@@ -174,21 +174,22 @@ class Client implements APIClient
     public function transferCallWithNCCO(string $callId, NCCO $ncco) : void
     {
         $this->api->update($callId, [
+            'action' => 'transfer',
             'destination' => [
-                'action' => 'transfer',
+                'type' => 'ncco',
+                'ncco' => $ncco->toArray()
             ],
-            'type' => 'ncco',
-            'ncco' => $ncco->toArray()
         ]);
     }
 
     public function transferCallWithUrl(string $callId, string $url) : void
     {
         $this->api->update($callId, [
+            'action' => 'transfer',
             'destination' => [
-                'action' => 'transfer',
-            ],
-            'url' => [$url],
+                'type' => 'ncco',
+                'url' => [$url]
+            ]
         ]);
     }
 

--- a/test/Voice/ClientTest.php
+++ b/test/Voice/ClientTest.php
@@ -285,16 +285,16 @@ class ClientTest extends TestCase
     {
         $id = 'ssf61863-4a51-ef6b-11e1-w6edebcf93bb';
         $payload = [
+            'action' => 'transfer',
             'destination' => [
-                'action' => 'transfer'
-            ],
-            'type' => 'ncco',
-            'ncco' => [
-                [
-                    'action' => 'talk',
-                    'text' => 'Thank you for trying Vonage',
+                'type' => 'ncco',
+                'ncco' => [
+                    [
+                        'action' => 'talk',
+                        'text' => 'Thank you for trying Vonage',
+                    ]
                 ]
-            ]
+            ],
         ];
 
         $this->vonageClient->send(Argument::that(function (RequestInterface $request) use ($id, $payload) {
@@ -314,10 +314,11 @@ class ClientTest extends TestCase
     {
         $id = 'ssf61863-4a51-ef6b-11e1-w6edebcf93bb';
         $payload = [
+            'action' => 'transfer',
             'destination' => [
-                'action' => 'transfer'
+                'type' => 'ncco',
+                'url' => ['https://test.domain/transfer.json'],
             ],
-            'url' => ['https://test.domain/transfer.json'],
         ];
 
         $this->vonageClient->send(Argument::that(function (RequestInterface $request) use ($id, $payload) {


### PR DESCRIPTION
Not sure if this got mangled in a merge at some point, but the JSON for transferring a call was off. This corrects that, but also fixes where transferring via a URL matched the docs, but the docs were wrong (and are being corrected).

## Testing

1. Create a new folder and enter it
2. Run
    `composer require nexmo/client-core:dev-bug/fix-voice-transfers@dev php-http/guzzle6-adapter`
3. Copy the below script to `transfer.php`
4. Call yourself with :
     `KEY_PATH=<path_to_app_key> APP_ID=<app_id> TO_NUMBER=<number_to_call> FROM_NUMBER=<vonage_number> php transfer.php --call`
5. Take the Call UUID from the above command and run the following to transfer with a URL:
    `KEY_PATH=<path_to_app_key> APP_ID=<app_id> UUID=<call_uuid> php transfer.php --transfer-url`
6. Call yourself again, take the Call UUID and run the following to transfer with an inline NCCO:
    `KEY_PATH=<path_to_app_key> APP_ID=<app_id> UUID=<call_uuid> php transfer.php --transfer-ncco`

```php
<?php

use Laminas\Diactoros\Response\Serializer;
use Nexmo\Client\Credentials\Keypair;
use Nexmo\Voice\Endpoint\Phone;
use Nexmo\Voice\NCCO\Action\Conversation;
use Nexmo\Voice\NCCO\Action\Talk;
use Nexmo\Voice\NCCO\NCCO;
use Nexmo\Voice\OutboundCall;

require_once __DIR__ . '/vendor/autoload.php';

$client = new Nexmo\Client(
    new Keypair(
        file_get_contents(getenv('KEY_PATH')),
        getenv('APP_ID')
    )
);

if ('--call' === $argv[1]) {
    $call = (new OutboundCall(new Phone(getenv('TO_NUMBER')), new Phone(getenv('FROM_NUMBER'))))
        ->setNCCO((new NCCO())->addAction(new Conversation('test-convo')))
    ;
    $callInfo = $client->voice()->createOutboundCall($call);
    echo $callInfo->getUuid() . PHP_EOL;
}

if ('--transfer-url' === $argv[1]) {
    try {
        $response = $client->voice()->transferCallWithUrl(getenv('UUID'), 'https://developer.nexmo.com/ncco/transfer.json');
    } catch (\Exception $e) {
        echo Serializer::toString($client->voice()->getAPIResource()->getLastResponse());
    }
}

if ('--transfer-ncco' === $argv[1]) {
    try {
        $ncco = (new NCCO())->addAction(new Talk('Transferred with NCCO'));
        $client->voice()->transferCallWithNCCO(getenv('UUID'), $ncco);
    } catch (\Exception $e) {
        echo Serializer::toString($client->voice()->getAPIResource()->getLastResponse());
    }
}

```