### PR TITLE
Added support for the PSD2 endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,15 @@ Using your signature secret and the other supplied parameters, the signature can
 Vonage's [Verify API][doc_verify] makes it easy to prove that a user has provided their own phone number during signup,
 or implement second factor authentication during signin.
 
-You can start a verification process using a simple array:
+You can start a verification process using code like this:
 
 ```php
 $request = new \Vonage\Verify\Request('14845551212', 'My App');
 $response = $client->verify()->start($request);
 echo "Started verification with an id of: " . $response->getRequestId();
 ```
+
+Once the user inputs the pin code they received, call the `/check` endpoint with the request ID and the pin to confirm the pin is correct.
 
 ### Controlling a Verification
     
@@ -209,6 +211,20 @@ foreach($verification->getChecks() as $check){
     echo $check->getDate()->format('d-m-y') . ' ' . $check->getStatus() . PHP_EOL;
 }
 ```
+
+### Payment Verification
+
+Vonage's [Verify API][doc_verify] has SCA (Secure Customer Authentication) support, required by the PSD2 (Payment Services Directive) and used by applications that need to get confirmation from customers for payments. It includes the payee and the amount in the message.
+
+Start the verification for a payment like this:
+
+```php
+$request = new \Vonage\Verify\RequestPSD2('14845551212', 'My App');
+$response = $client->verify()->requestPSD2($request);
+echo "Started verification with an id of: " . $response['request_id'];
+```
+
+Once the user inputs the pin code they received, call the `/check` endpoint with the request ID and the pin to confirm the pin is correct.
 
 ### Making a Call 
 

--- a/src/Verify/Client.php
+++ b/src/Verify/Client.php
@@ -79,6 +79,19 @@ class Client implements ClientAwareInterface, APIClient
     }
 
     /**
+     * @return array{request_id: string, status: string}
+     */
+    public function requestPSD2(RequestPSD2 $request) : array
+    {
+        $api = $this->getApiResource();
+        $response = $api->create($request->toArray(), '/psd2/json');
+
+        $this->checkError($request, $response);
+
+        return $response;
+    }
+
+    /**
      * @param string|Verification $verification
      */
     public function search($verification)
@@ -224,7 +237,7 @@ class Client implements ClientAwareInterface, APIClient
         return $this->checkError($verification, $data);
     }
 
-    protected function checkError(Verification $verification, $data)
+    protected function checkError($verification, $data)
     {
         if (!isset($data['status'])) {
             $e = new Exception\Request('unexpected response from API');

--- a/src/Verify/RequestPSD2.php
+++ b/src/Verify/RequestPSD2.php
@@ -1,0 +1,238 @@
+<?php
+declare(strict_types=1);
+
+namespace Nexmo\Verify;
+
+use Nexmo\Entity\Hydrator\ArrayHydrateInterface;
+
+class RequestPSD2 implements ArrayHydrateInterface
+{
+    const PIN_LENGTH_4 = 4;
+    const PIN_LENGTH_6 = 6;
+
+    const WORKFLOW_SMS_TTS_TSS = 1;
+    const WORKFLOW_SMS_SMS_TSS = 2;
+    const WORKFLOW_TTS_TSS = 3;
+    const WORKFLOW_SMS_SMS = 4;
+    const WORKFLOW_SMS_TTS = 5;
+    const WORKFLOW_SMS = 6;
+    const WORKFLOW_TTS = 7;
+    
+    /**
+     * @var string
+     */
+    protected $number;
+
+    /**
+     * @var string
+     */
+    protected $country;
+
+    /**
+     * @var string
+     */
+    protected $payee;
+
+    /**
+     * @var string
+     */
+    protected $amount;
+
+    /**
+     * @var int
+     */
+    protected $codeLength;
+
+    /**
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * @var int
+     */
+    protected $pinExpiry;
+
+    /**
+     * @var int
+     */
+    protected $nextEventWait;
+
+    /**
+     * @var int
+     */
+    protected $workflowId;
+
+    public function __construct(string $number, string $payee, string $amount, int $workflowId = null)
+    {
+        $this->number = $number;
+        $this->payee = $payee;
+        $this->amount = $amount;
+
+        if ($workflowId) {
+            $this->setWorkflowId($workflowId);
+        }
+    }
+
+    public function getCountry() : ?string
+    {
+        return $this->country;
+    }
+
+    public function setCountry(string $country) : self
+    {
+        if (strlen($country) !== 2) {
+            throw new \InvalidArgumentException('Country must be in two character format');
+        }
+        $this->country = $country;
+        return $this;
+    }
+
+    public function getCodeLength() : ?int
+    {
+        return $this->codeLength;
+    }
+
+    public function setCodeLength(int $codeLength) : self
+    {
+        if ($codeLength !== 4 || $codeLength !== 6) {
+            throw new \InvalidArgumentException('Pin length must be either 4 or 6 digits');
+        }
+
+        $this->codeLength = $codeLength;
+        return $this;
+    }
+
+    public function getLocale() : ?string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(string $locale) : self
+    {
+        $this->locale = $locale;
+        return $this;
+    }
+
+    public function getPinExpiry() : ?int
+    {
+        return $this->pinExpiry;
+    }
+
+    public function setPinExpiry(int $pinExpiry) : self
+    {
+        if ($pinExpiry < 60 || $pinExpiry > 3600) {
+            throw new \InvalidArgumentException('Pin expiration must be between 60 and 3600 seconds');
+        }
+
+        $this->pinExpiry = $pinExpiry;
+        return $this;
+    }
+
+    public function getNextEventWait() : ?int
+    {
+        return $this->nextEventWait;
+    }
+
+    public function setNextEventWait(int $nextEventWait) : self
+    {
+        if ($nextEventWait < 60 || $nextEventWait > 3600) {
+            throw new \InvalidArgumentException('Next Event time must be between 60 and 900 seconds');
+        }
+
+        $this->nextEventWait = $nextEventWait;
+        return $this;
+    }
+
+    public function getWorkflowId() : ?int
+    {
+        return $this->workflowId;
+    }
+
+    public function setWorkflowId(int $workflowId) : self
+    {
+        if ($workflowId < 1 || $workflowId > 7) {
+            throw new \InvalidArgumentException('Workflow ID must be from 1 to 7');
+        }
+
+        $this->workflowId = $workflowId;
+        return $this;
+    }
+
+    public function getNumber() : string
+    {
+        return $this->number;
+    }
+
+    public function getPayee() : string
+    {
+        return $this->payee;
+    }
+
+    public function getAmount() : string
+    {
+        return $this->amount;
+    }
+
+    public function fromArray(array $data)
+    {
+        if (array_key_exists('code_length', $data)) {
+            $this->setCodeLength($data['code_length']);
+        }
+
+        if (array_key_exists('pin_expiry', $data)) {
+            $this->setPinExpiry($data['pin_expiry']);
+        }
+
+        if (array_key_exists('next_event_wait', $data)) {
+            $this->setNextEventWait($data['next_event_wait']);
+        }
+
+        if (array_key_exists('workflow_id', $data)) {
+            $this->setWorkflowId($data['workflow_id']);
+        }
+
+        if (array_key_exists('country', $data)) {
+            $this->setCountry($data['country']);
+        }
+
+        if (array_key_exists('lg', $data)) {
+            $this->setLocale($data['lg']);
+        }
+    }
+
+    public function toArray(): array
+    {
+        $data = [
+            'number' => $this->getNumber(),
+            'amount' => $this->getAmount(),
+            'payee' => $this->getPayee(),
+        ];
+
+        if ($this->getCodeLength()) {
+            $data['code_length'] = $this->getCodeLength();
+        }
+
+        if ($this->getPinExpiry()) {
+            $data['pin_expiry'] = $this->getPinExpiry();
+        }
+
+        if ($this->getNextEventWait()) {
+            $data['next_event_wait'] = $this->getNextEventWait();
+        }
+
+        if ($this->getWorkflowId()) {
+            $data['workflow_id'] = $this->getWorkflowId();
+        }
+
+        if ($this->getCountry()) {
+            $data['country'] = $this->getCountry();
+        }
+
+        if ($this->getLocale()) {
+            $data['lg'] = $this->getLocale();
+        }
+
+        return $data;
+    }
+}

--- a/src/Verify/RequestPSD2.php
+++ b/src/Verify/RequestPSD2.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace Nexmo\Verify;
+namespace Vonage\Verify;
 
-use Nexmo\Entity\Hydrator\ArrayHydrateInterface;
+use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 
 class RequestPSD2 implements ArrayHydrateInterface
 {

--- a/test/Verify/ClientTest.php
+++ b/test/Verify/ClientTest.php
@@ -133,7 +133,7 @@ class ClientTest extends TestCase
 
     public function testCanStartPSD2Verification()
     {
-        $this->nexmoClient->send(Argument::that(function (RequestInterface $request) {
+        $this->vonageClient->send(Argument::that(function (RequestInterface $request) {
             $this->assertRequestJsonBodyContains('number', '14845551212', $request);
             $this->assertRequestJsonBodyContains('payee', 'Test Verify', $request);
             $this->assertRequestJsonBodyContains('amount', '5.25', $request);
@@ -151,7 +151,7 @@ class ClientTest extends TestCase
 
     public function testCanStartPSD2VerificationWithWorkflowID()
     {
-        $this->nexmoClient->send(Argument::that(function (RequestInterface $request) {
+        $this->vonageClient->send(Argument::that(function (RequestInterface $request) {
             $this->assertRequestJsonBodyContains('number', '14845551212', $request);
             $this->assertRequestJsonBodyContains('payee', 'Test Verify', $request);
             $this->assertRequestJsonBodyContains('amount', '5.25', $request);


### PR DESCRIPTION
This adds support for the PSD2 endpoint for Verify, and a new Value Object to handle the request. This falls in line with what v3.0.0's Verify interface will look like.

```php
$request = new \Nexmo\Verify\RequestPSD2('12225551234', 'Payee', '9.99');
$response = $nexmo->verify()->requestPSD2($request);
echo $response['request_id'];
```