### PR TITLE
Fixed passing through and defaulting to client API URL

### DIFF
--- a/src/Client/APIResource.php
+++ b/src/Client/APIResource.php
@@ -19,7 +19,7 @@ class APIResource implements ClientAwareInterface
      * client or directly on this class.
      * @var string
      */
-    protected $baseUrl = Client::BASE_API;
+    protected $baseUrl = '';
 
     /**
      * @var string
@@ -66,7 +66,7 @@ class APIResource implements ClientAwareInterface
     public function create(array $body, string $uri = '') : ?array
     {
         $request = new Request(
-            $this->baseUrl . $this->baseUri . $uri,
+            $this->getBaseUrl() . $this->getBaseUri() . $uri,
             'POST',
             'php://temp',
             ['content-type' => 'application/json']
@@ -148,12 +148,18 @@ class APIResource implements ClientAwareInterface
         return $body;
     }
 
-    public function getBaseUrl() : string
+    public function getBaseUrl() : ?string
     {
+        if (!$this->baseUrl) {
+            if ($this->client) {
+                $this->baseUrl = $this->client->getApiUrl();
+            }
+        }
+
         return $this->baseUrl;
     }
 
-    public function getBaseUri() : string
+    public function getBaseUri() : ?string
     {
         return $this->baseUri;
     }
@@ -187,6 +193,7 @@ class APIResource implements ClientAwareInterface
     public function setExceptionErrorHandler(callable $handler)
     {
         $this->exceptionErrorHandler = $handler;
+        return $this;
     }
 
     protected function getException(ResponseInterface $response, RequestInterface $request)

--- a/test/Client/APIResourceTest.php
+++ b/test/Client/APIResourceTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace NexmoTest\Client;
+
+use PHPUnit\Framework\TestCase;
+use Vonage\Client;
+use Vonage\Client\APIResource;
+
+class APIResourceTest extends TestCase
+{
+    public function testOverridingBaseUrlUsesClientApiUrl()
+    {
+        $mockClient = $this->prophesize(Client::class);
+        $mockClient->getApiUrl()->willReturn('https://test.domain');
+
+        $resource = new APIResource();
+        $resource->setClient($mockClient->reveal());
+
+        $this->assertSame('https://test.domain', $resource->getBaseUrl());
+    }
+
+    public function testOverridingBaseUrlManuallyWorks()
+    {
+        $resource = new APIResource();
+        $resource->setBaseUrl('https://test.domain');
+
+        $this->assertSame('https://test.domain', $resource->getBaseUrl());
+    }
+
+    public function testNotOverridingBaseURLReturnsBlank()
+    {
+        $resource = new APIResource();
+        $this->assertSame('', $resource->getBaseUrl());
+    }
+}

--- a/test/SMS/ClientTest.php
+++ b/test/SMS/ClientTest.php
@@ -46,6 +46,7 @@ class ClientTest extends TestCase
             ->setErrorsOn200(true)
             ->setClient($this->vonageClient->reveal())
             ->setExceptionErrorHandler(new ExceptionErrorHandler())
+            ->setBaseUrl('https://rest.nexmo.com')
         ;
 
         $this->smsClient = new Client($this->api);


### PR DESCRIPTION
By default, the `\Vonage\Client\APIResource` would use the default Base API URL from the `\Vonage\Client::BASE_API` constant. If the user override the API URL, this was never passed through to the `\Vonage\Client\APIResource`. Rest URL overrides would be, because most of the factories for APIs hitting `rest.nexmo.com` would pass this up manually.

Defaulting to the API URL was because most of the APIs use `api.nexmo.com`, and `rest.nexmo.com` is only handling a few legacy APIs.

This fix makes it so the `\Vonage\Client\APIResource` defaults to a blank URL, and if a client is assigned to grab the client's API URL. Otherwise it returns a blank, and the underling HTTP Client can deal with it.

This also includes a minor fix where setting the Exception Handler on the API resource didn't return `$this`, breaking chaining.