### PR TITLE
Added bridge package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     "laminas/laminas-diactoros": "^1.8.4 || ^2.0",
     "lcobucci/jwt": "^3.2",
     "ocramius/package-versions": "^1.4",
-    "psr/container": "^1.0"
+    "psr/container": "^1.0",
+    "vonage/nexmo-bridge": "^0.1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.4",


### PR DESCRIPTION
This adds in the ability for both the `\Nexmo` and `\Vonage` namespaces to be used interchangeably. With this addition, the `vonage/client` and `vonage/client-core` are drop in replacements for their `nexmo/client` and `nexmo/client-core` analogues. Users can then update to the `\Vonage` namespace at their leisure.

From a technical perspective, this allows us to easily keep support for "Nexmo" code while shipping it under the "Vonage" name.

This can be tested by removing `nexmo/client` and replacing with `vonage/client-core` and an HTTPlug-compatible library.

```bash
composer remove nexmo/client nexmo-client-core
composer require vonage/client-core:dev-feature/bridge@dev php-http/guzzle6-adapter
```

No other changes need to be made to the client's code.