### PR TITLE
Added three getter methods for values returned in the Standard Insights API

### DIFF
--- a/src/Insights/Standard.php
+++ b/src/Insights/Standard.php
@@ -18,6 +18,21 @@ class Standard extends Basic
         return $this->data['ported'];
     }
 
+    public function getRefundPrice()
+    {
+        return $this->data['refund_price'];
+    }
+
+    public function getRequestPrice()
+    {
+        return $this->data['request_price'];
+    }
+
+    public function getRemainingBalance()
+    {
+        return $this->data['remaining_balance'];
+    }
+
     public function getRoaming()
     {
         return $this->data['roaming'];

--- a/test/Insights/StandardTest.php
+++ b/test/Insights/StandardTest.php
@@ -20,6 +20,9 @@ class StandardTest extends TestCase
      */
     public function testArrayAccess($standard, $inputData)
     {
+        $this->assertEquals($inputData['refund_price'], @$standard['refund_price']);
+        $this->assertEquals($inputData['request_price'], @$standard['request_price']);
+        $this->assertEquals($inputData['remaining_balance'], @$standard['remaining_balance']);
         $this->assertEquals($inputData['current_carrier'], @$standard['current_carrier']);
         $this->assertEquals($inputData['original_carrier'], @$standard['original_carrier']);
         $this->assertEquals($inputData['ported'], @$standard['ported']);
@@ -31,6 +34,9 @@ class StandardTest extends TestCase
      */
     public function testObjectAccess($standard, $inputData)
     {
+        $this->assertEquals($inputData['refund_price'], @$standard->getRefundPrice());
+        $this->assertEquals($inputData['request_price'], @$standard->getRequestPrice());
+        $this->assertEquals($inputData['remaining_balance'], @$standard->getRemainingBalance());
         $this->assertEquals($inputData['current_carrier'], $standard->getCurrentCarrier());
         $this->assertEquals($inputData['original_carrier'], $standard->getOriginalCarrier());
         $this->assertEquals($inputData['ported'], $standard->getPorted());
@@ -57,6 +63,9 @@ class StandardTest extends TestCase
                     'network_type' => 'mobile',
                 ],
             'ported' => 'assumed_ported',
+            'request_price' => '0.00500000',
+            'refund_price' => '0.00500000',
+            'remaining_balance' => '26.294675',
             'roaming' =>
                 [
                     'status' => 'unknown',

--- a/test/Insights/responses/standard.json
+++ b/test/Insights/responses/standard.json
@@ -9,6 +9,7 @@
   "country_name": "United Kingdom",
   "country_prefix": "44",
   "request_price": "0.00500000",
+  "refund_price": "0.00500000",
   "remaining_balance": "26.294675",
   "current_carrier": {
     "network_code": "23420",


### PR DESCRIPTION
## Description
The Insights API, the standard endpoint was missing three values, remaining balance, request price, and refund price. I've added the methods to retrieve these values.

## Motivation and Context
This change ensures that all values of the API response can be retrieved via the object because the array values are deprecated and due to be removed in a future version

## How Has This Been Tested?
I ran the request myself. The values were retrievable. I also updated the PHPUnit tests to reflect these expectations.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
