### PR TITLE
Added make() method to bypass service locator caching

### DIFF
--- a/src/Account/Client.php
+++ b/src/Account/Client.php
@@ -41,7 +41,7 @@ class Client implements ClientAwareInterface, APIClient
      * Shim to handle older instatiations of this class
      * @deprecated Will remove in v3
      */
-    protected function getAccountAPI() : APIResource
+    public function getAccountAPI() : APIResource
     {
         if (is_null($this->accountAPI)) {
             $api = new APIResource();
@@ -65,7 +65,7 @@ class Client implements ClientAwareInterface, APIClient
      * Shim to handle older instatiations of this class
      * @deprecated Will remove in v3
      */
-    protected function getSecretsAPI() : APIResource
+    public function getSecretsAPI() : APIResource
     {
         if (is_null($this->secretsAPI)) {
             $api = new APIResource();

--- a/src/Account/ClientFactory.php
+++ b/src/Account/ClientFactory.php
@@ -11,14 +11,14 @@ class ClientFactory
     public function __invoke(ContainerInterface $container) : Client
     {
         /** @var APIResource $accountApi */
-        $accountApi = $container->get(APIResource::class);
+        $accountApi = $container->make(APIResource::class);
         $accountApi
             ->setBaseUrl($accountApi->getClient()->getRestUrl())
             ->setIsHAL(false)
             ->setBaseUri('/account')
         ;
 
-        $secretsApi = $container->get(APIResource::class);
+        $secretsApi = $container->make(APIResource::class);
         $secretsApi->setBaseUri('/account');
 
         return new Client($accountApi, $secretsApi);

--- a/src/Account/ClientFactory.php
+++ b/src/Account/ClientFactory.php
@@ -19,7 +19,7 @@ class ClientFactory
         ;
 
         $secretsApi = $container->make(APIResource::class);
-        $secretsApi->setBaseUri('/account');
+        $secretsApi->setBaseUri('/accounts');
 
         return new Client($accountApi, $secretsApi);
     }

--- a/src/Application/ClientFactory.php
+++ b/src/Application/ClientFactory.php
@@ -14,7 +14,7 @@ class ClientFactory
     public function __invoke(ContainerInterface $container) : Client
     {
         /** @var APIResource $api */
-        $api = $container->get(APIResource::class);
+        $api = $container->make(APIResource::class);
         $api
             ->setBaseUri('/v2/applications')
             ->setCollectionName('applications')

--- a/src/Client/Factory/MapFactory.php
+++ b/src/Client/Factory/MapFactory.php
@@ -59,7 +59,28 @@ class MapFactory implements FactoryInterface, ContainerInterface
             return $this->cache[$key];
         }
 
-        if (!$this->hasApi($key)) {
+        $instance = $this->make($key);
+        $this->cache[$key] = $instance;
+
+        return $instance;
+    }
+
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    /**
+     * @deprecated Use get() instead
+     */
+    public function getApi($api)
+    {
+        return $this->get($api);
+    }
+
+    public function make($key)
+    {
+        if (!$this->has($key)) {
             throw new \RuntimeException(sprintf(
                 'no map defined for `%s`',
                 $key
@@ -79,21 +100,8 @@ class MapFactory implements FactoryInterface, ContainerInterface
         if ($instance instanceof Client\ClientAwareInterface) {
             $instance->setClient($this->client);
         }
-        $this->cache[$key] = $instance;
+
         return $instance;
-    }
-
-    public function getClient()
-    {
-        return $this->client;
-    }
-
-    /**
-     * @deprecated Use get() instead
-     */
-    public function getApi($api)
-    {
-        return $this->get($api);
     }
 
     public function set($key, $value)

--- a/src/Conversion/ClientFactory.php
+++ b/src/Conversion/ClientFactory.php
@@ -14,7 +14,7 @@ class ClientFactory
     public function __invoke(ContainerInterface $container) : Client
     {
         /** @var APIResource $api */
-        $api = $container->get(APIResource::class);
+        $api = $container->make(APIResource::class);
         $api->setBaseUri('/conversions/');
 
         return new Client($api);

--- a/src/Insights/ClientFactory.php
+++ b/src/Insights/ClientFactory.php
@@ -11,7 +11,7 @@ class ClientFactory
     public function __invoke(ContainerInterface $container) : Client
     {
         /** @var APIResource $api */
-        $api = $container->get(APIResource::class);
+        $api = $container->make(APIResource::class);
         $api->setIsHAL(false);
 
         return new Client($api);

--- a/src/Numbers/ClientFactory.php
+++ b/src/Numbers/ClientFactory.php
@@ -11,7 +11,7 @@ class ClientFactory
     public function __invoke(ContainerInterface $container) : Client
     {
         /** @var APIResource $api */
-        $api = $container->get(APIResource::class);
+        $api = $container->make(APIResource::class);
         $api
             ->setBaseUrl($api->getClient()->getRestUrl())
             ->setIsHAL(false)

--- a/src/Redact/ClientFactory.php
+++ b/src/Redact/ClientFactory.php
@@ -15,7 +15,7 @@ class ClientFactory
     public function __invoke(ContainerInterface $container) : Client
     {
         /** @var APIResource $api */
-        $api = $container->get(APIResource::class);
+        $api = $container->make(APIResource::class);
         $api
             ->setBaseUri('/v1/redact/transaction')
             ->setCollectionName('')

--- a/src/SMS/ClientFactory.php
+++ b/src/SMS/ClientFactory.php
@@ -11,7 +11,7 @@ class ClientFactory
     public function __invoke(ContainerInterface $container) : Client
     {
         /** @var APIResource $api */
-        $api = $container->get(APIResource::class);
+        $api = $container->make(APIResource::class);
         $api
             ->setBaseUrl($api->getClient()->getRestUrl())
             ->setCollectionName('messages')

--- a/src/Verify/ClientFactory.php
+++ b/src/Verify/ClientFactory.php
@@ -11,7 +11,7 @@ class ClientFactory
     public function __invoke(ContainerInterface $container) : Client
     {
         /** @var APIResource $api */
-        $api = $container->get(APIResource::class);
+        $api = $container->make(APIResource::class);
         $api
             ->setIsHAL(false)
             ->setBaseUri('/verify')

--- a/src/Voice/ClientFactory.php
+++ b/src/Voice/ClientFactory.php
@@ -11,7 +11,7 @@ class ClientFactory
     public function __invoke(ContainerInterface $container) : Client
     {
         /** @var APIResource $api */
-        $api = $container->get(APIResource::class);
+        $api = $container->make(APIResource::class);
         $api
             ->setBaseUri('/v1/calls')
             ->setCollectionName('calls')

--- a/test/Account/ClientFactoryTest.php
+++ b/test/Account/ClientFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace NexmoTest\Account;
+
+use Vonage\Account\Client;
+use Vonage\Client\APIResource;
+use PHPUnit\Framework\TestCase;
+use Vonage\Account\ClientFactory;
+use Vonage\Client\Factory\MapFactory;
+
+class ClientFactoryTest extends TestCase
+{
+    /**
+     * @var MapFactory
+     */
+    protected $mapFactory;
+
+    /**
+     * @var Client
+     */
+    protected $vonageClient;
+
+    public function setUp()
+    {
+        $this->vonageClient = $this->prophesize('Vonage\Client');
+        $this->vonageClient->getRestUrl()->willReturn('https://rest.nexmo.com');
+        $this->vonageClient->getApiUrl()->willReturn('https://api.nexmo.com');
+
+        $this->mapFactory = new MapFactory([
+            APIResource::class => APIResource::class
+        ], $this->vonageClient->reveal());
+    }
+    
+    public function testURIsAreCorrect()
+    {
+        $factory = new ClientFactory();
+        /** @var Client $client */
+        $client = $factory($this->mapFactory);
+
+        $this->assertSame('/accounts', $client->getSecretsAPI()->getBaseUri());
+        $this->assertSame('https://api.nexmo.com', $client->getSecretsAPI()->getBaseUrl());
+
+        $this->assertSame('/account', $client->getAccountAPI()->getBaseUri());
+        $this->assertSame('https://rest.nexmo.com', $client->getAccountAPI()->getBaseUrl());
+    }
+}

--- a/test/Client/Factory/MapFactoryTest.php
+++ b/test/Client/Factory/MapFactoryTest.php
@@ -58,4 +58,25 @@ class MapFactoryTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->factory->getApi('not');
     }
+
+    public function testMakeCreatesNewInstance()
+    {
+        $first = $this->factory->make('test');
+        $second = $this->factory->make('test');
+
+        $this->assertNotSame($first, $second);
+        $this->assertInstanceOf('VonageTest\Client\Factory\TestDouble', $first);
+        $this->assertInstanceOf('VonageTest\Client\Factory\TestDouble', $second);
+    }
+
+    public function testMakeDoesNotUseCache()
+    {
+        $cached = $this->factory->get('test');
+        $new = $this->factory->make('test');
+        $secondCached = $this->factory->get('test');
+
+        $this->assertNotSame($cached, $new);
+        $this->assertNotSame($secondCached, $new);
+        $this->assertSame($cached, $secondCached);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `\Vonage\Client\Factory\MapFactory` originally worked by using a cache to cut down on object instantiation. This adds a `make()` method so that the cache can be bypassed and the object pulled from the `MapFactory` is always instantiated fresh.

This also includes a few tweaks to the Account Client to make it easier to test, and a typo-fix for the Account ClientFactory.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@slorello89 noticed that with the Secrets API, it would try and use `rest.nexmo.com` instead of `api.nexmo.com`. This was because the `\Vonage\Accounts\ClientFactory` generates two `\Vonage\Client\APIResource` objects, as Secrets and Accounts have two different base URLs.

Because PHP always uses references when passing around objects, the `MapFactory` instance was updated to use `rest.nexmo.com` instead of the default `api.nexmo.com`.

While I could just fix the `ClientFactory`, that doesn't solve the underlying problem if multiple APIs are used in a single script.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally against the code snippet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
