### PR TITLE
Bump minimum PHP version to 7.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
             - ubuntu-latest
         strategy:
             matrix:
-                php: ['7.1', '7.2', '7.3', '7.4']
+                php: ['7.2', '7.3', '7.4']
         steps:
             - name: Configure Git
               if: ${{ matrix.os == 'windows-latest' }}

--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ curl.cainfo = "C:\php\extras\ssl\cacert.pem"
 
 ### Pass custom HTTP client
 
-We allow use of any HTTPlug adapter, so you can create a client with alternative configuration if you need it, for example to take account of a local proxy, or deal with something else specific to your setup.
+We allow use of any HTTPlug adapter or PSR-18 compatible HTTP client, so you can create a client with alternative configuration if you need it, for example to take account of a local proxy, or deal with something else specific to your setup.
 
 Here's an example that reduces the default timeout to 5 seconds to avoid long delays if you have no route to our servers:
 
@@ -684,7 +684,7 @@ When things go wrong, you'll receive an `Exception`. The Vonage exception classe
 
 ### Composer installation fails due to Guzzle Adapter
 
-If you have a conflicting package installation that cannot co-exist with our recommended `php-http/guzzle6-adapter` package, then you may install the package `vonage/client-core` along with any package that satisfies the `php-http/client-implementation` requirement.
+If you have a conflicting package installation that cannot co-exist with our recommended `guzzlehttp/guzzle` package, then you may install the package `vonage/client-core` along with any package that satisfies the `php-http/client-implementation` requirement.
 
 See the [Packagist page for client-implementation](https://packagist.org/providers/php-http/client-implementation) for options.
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "email": "devrel@nexmo.com"
   },
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "psr/http-client-implementation": "^1.0",
     "laminas/laminas-diactoros": "^1.8.4 || ^2.0",
     "lcobucci/jwt": "^3.2",
@@ -43,7 +43,7 @@
     "php-http/mock-client": "^1.4",
     "estahn/phpunit-json-assertions": "^3.0.0",
     "squizlabs/php_codesniffer": "^3.1",
-    "php-http/guzzle6-adapter": "^2.0",
+    "guzzlehttp/guzzle": "^7.0",
     "phpstan/phpstan": "^0.12.11"
   },
   "autoload": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -77,7 +77,13 @@ class Client
     public function __construct(CredentialsInterface $credentials, $options = array(), ClientInterface $client = null)
     {
         if (is_null($client)) {
-            $client = new \Http\Adapter\Guzzle6\Client();
+            // Since the user did not pass a client, try and make a client
+            // using the Guzzle 6 adapter or Guzzle 7
+            if (class_exists(\Http\Adapter\Guzzle6\Client::class)) {
+                $client = new \Http\Adapter\Guzzle6\Client();
+            } elseif (class_exists(\GuzzleHttp\Client::class)) {
+                $client = new \GuzzleHttp\Client();
+            }
         }
 
         $this->setHttpClient($client);

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -8,7 +8,7 @@
 
 namespace VonageTest;
 
-use Http\Adapter\Guzzle6\Client as HttpClient;
+use GuzzleHttp\Client as HttpClient;
 use Http\Message\MessageFactory\DiactorosMessageFactory;
 use Http\Mock\Client as HttpMock;
 use Vonage\Client;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Package now requires PHP 7.2 or higher
* Changed dev dependency from Guzzle Adapter to straight Guzzle 7
* Support either the Guzzle 6 HTTPlug adapter _or_ Guzzle 7 automatically if the classes exist
* Dropped PHP 7.1 from testing matrix
* Updated docs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Laravel 8 was released, which now ships with and recommends upgrading to Guzzle 7. This impacts our `nexmo/laravel` package as it requires Guzzle 6. While there is a workaround, this still causes friction with users. Updating the core library makes it easier to update the Laravel package.

PHP 7.1 is also EOL, and only represents 3-4% of API usage on Vonage, with PHP 7.2+ representing ~73% of usage (the resulting ~27% are 7.1 or lower versions that we no longer support officially). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested against a few code snippets, since all the code snippets use the `\Vonage\Client` object and whatever HTTP client it's configured to (in this case, Guzzle 7 by default).

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
