### PR TITLE
Bug/eventurl as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.3.3
+
+### Fixed
+
+* #252 - Connect action's `eventUrl` was being set as a string, changed to single element array of strings
+
 # 2.3.2
 
 ### Added

--- a/src/Voice/NCCO/Action/Connect.php
+++ b/src/Voice/NCCO/Action/Connect.php
@@ -101,7 +101,7 @@ class Connect implements ActionInterface
 
         $eventWebhook = $this->getEventWebhook();
         if ($eventWebhook) {
-            $data['eventUrl'] = $eventWebhook->getUrl();
+            $data['eventUrl'] = [$eventWebhook->getUrl()];
             $data['eventMethod'] = $eventWebhook->getMethod();
         }
 

--- a/test/Voice/NCCO/Action/ConnectTest.php
+++ b/test/Voice/NCCO/Action/ConnectTest.php
@@ -85,7 +85,7 @@ class ConnectTest extends TestCase
         $this->assertSame(6000, $ncco['limit']);
         $this->assertSame('https://test.domain/ringback.mp3', $ncco['ringbackTone']);
         $this->assertSame(10, $ncco['timeout']);
-        $this->assertSame('https://test.domain/events', $ncco['eventUrl']);
+        $this->assertSame(['https://test.domain/events'], $ncco['eventUrl']);
         $this->assertSame('POST', $ncco['eventMethod']);
     }
 
@@ -112,7 +112,7 @@ class ConnectTest extends TestCase
         $this->assertSame(6000, $ncco['limit']);
         $this->assertSame('https://test.domain/ringback.mp3', $ncco['ringbackTone']);
         $this->assertSame(10, $ncco['timeout']);
-        $this->assertSame('https://test.domain/events', $ncco['eventUrl']);
+        $this->assertSame(['https://test.domain/events'], $ncco['eventUrl']);
         $this->assertSame('POST', $ncco['eventMethod']);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes bug where the `eventUrl` key in a Connect NCCO was a string instead of a single element array. Ported from Nexmo/nexmo-php#1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This stops the Connect action from working with an external NCCO when used with the Voice API.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing using a sample script I have for making calls.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
