### PR TITLE
Removed extra ( in example code for making a call that will cause PHP Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ All `$client->voice()` methods require the client to be constructed with a `Vona
 ```php
 $basic  = new \Vonage\Client\Credentials\Basic('key', 'secret');
 $keypair = new \Vonage\Client\Credentials\Keypair(
-    file_get_contents((NEXMO_APPLICATION_PRIVATE_KEY_PATH),
+    file_get_contents(NEXMO_APPLICATION_PRIVATE_KEY_PATH),
     NEXMO_APPLICATION_ID
 );
 


### PR DESCRIPTION
## Description
Within the README, under `Make a Call` there was an extra `(` under the part that calls `file_get_contents()`. If anyone copied this, it would have caused errors in their code.

## Motivation and Context
It stops people from encountering errors when copying our code examples

## How Has This Been Tested?
I tested this myself, but also copied the example and my linter found no issues once rectified.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
