### PR TITLE
Updated NEXMO_ references to VONAGE_ in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To use [Vonage's SMS API][doc_sms] to send an SMS message, call the `$client->sm
 required parameters, and a fluent interface provides access to optional parameters.
 
 ```php
-$text = new \Vonage\SMS\Message\SMS(NEXMO_TO, NEXMO_FROM, 'Test message using PHP client library');
+$text = new \Vonage\SMS\Message\SMS(VONAGE_TO, VONAGE_FROM, 'Test message using PHP client library');
 $text->setClientRef('test-message');
 ```
 
@@ -234,8 +234,8 @@ All `$client->voice()` methods require the client to be constructed with a `Vona
 ```php
 $basic  = new \Vonage\Client\Credentials\Basic('key', 'secret');
 $keypair = new \Vonage\Client\Credentials\Keypair(
-    file_get_contents((NEXMO_APPLICATION_PRIVATE_KEY_PATH),
-    NEXMO_APPLICATION_ID
+    file_get_contents((VONAGE_APPLICATION_PRIVATE_KEY_PATH),
+    VONAGE_APPLICATION_ID
 );
 
 $client = new \Vonage\Client(new \Vonage\Client\Credentials\Container($basic, $keypair));
@@ -458,7 +458,7 @@ $client->numbers()->purchase('14155550100', 'US');
 To update a number, use `numbers()->update` and pass in the configuration options you want to change. To clear a setting, pass in an empty value.
 
 ```php
-$number = $client->numbers()->get(NEXMO_NUMBER);
+$number = $client->numbers()->get(VONAGE_NUMBER);
 $number
     ->setAppId('1a20a124-1775-412b-b623-e6985f4aace0')
     ->setVoiceDestination('447700900002', 'tel')


### PR DESCRIPTION
Due to the Rebrand, references to NEXMO have been updated to Vonage. This includes the placeholders where users are instructed to replace the values with their own unique values

## Description
Updated all references to NEXMO_ placeholders with VONAGE_ placeholders

## Motivation and Context
This problem continues the process of the SDK rebrand from Nexmo to Vonage

## How Has This Been Tested?
No code needs testing, I have viewed the changes through a markdown previewer however.

## Example Output or Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
