### PR TITLE
Converts $options to array if parameter it's a FilterInterface instance on Vonage\Numbers\Client::searchAvailable()

### DIFF
--- a/src/Numbers/Client.php
+++ b/src/Numbers/Client.php
@@ -193,6 +193,10 @@ class Client implements ClientAwareInterface, APIClient
             'index' => 'integer'
         ];
 
+        if ($options instanceof FilterInterface) {
+            $options = $options->getQuery();
+        }
+
         $options = $this->parseParameters($possibleParameters, $options);
         $options = new AvailableNumbers($options);
         $api = $this->getApiResource();

--- a/test/Numbers/ClientTest.php
+++ b/test/Numbers/ClientTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use VonageTest\Psr7AssertionTrait;
 use Vonage\Client\Exception\Request;
 use Psr\Http\Message\RequestInterface;
+use Vonage\Numbers\Filter\AvailableNumbers;
 
 class ClientTest extends TestCase
 {
@@ -207,6 +208,26 @@ class ClientTest extends TestCase
                 $this->assertRequestQueryContains($name, $value, $request);
             }
 
+            return true;
+        }))->willReturn($this->getResponse('available-numbers'));
+
+        @$this->numberClient->searchAvailable('US', $options);
+    }
+
+    public function testSearchAvailableAcceptsFilterInterfaceOptions()
+    {
+        $options = new AvailableNumbers([
+            'pattern' => '1',
+            'search_pattern' => 2,
+            'features' => 'SMS,VOICE',
+            'size' => 100,
+            'index' => 19
+        ]);
+
+        $this->vonageClient->send(Argument::that(function (RequestInterface $request) {
+            $this->assertEquals('/number/search', $request->getUri()->getPath());
+            $this->assertEquals('rest.nexmo.com', $request->getUri()->getHost());
+            $this->assertEquals('GET', $request->getMethod());
             return true;
         }))->willReturn($this->getResponse('available-numbers'));
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Converts `$options` to array before parsing parameters on `Vonage\Numbers\Client::searchAvailable()`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using a `FilterInterface` stops the method from working at all if you use a filter, which is the recommended way. While a raw array will work, the expectation is to use a filter.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, in a test file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
