### PR TITLE
Compatible with phpunit 8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "vonage/nexmo-bridge": "^0.1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.4",
+    "phpunit/phpunit": "^7.4 || ^8.0",
     "php-http/mock-client": "^1.4",
     "estahn/phpunit-json-assertions": "^3.0.0",
     "squizlabs/php_codesniffer": "^3.1",

--- a/test/Account/BalanceTest.php
+++ b/test/Account/BalanceTest.php
@@ -18,7 +18,7 @@ class BalanceTest extends TestCase
      */
     protected $balance;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->balance = new Balance('12.99', false);
     }

--- a/test/Account/ClientFactoryTest.php
+++ b/test/Account/ClientFactoryTest.php
@@ -21,7 +21,7 @@ class ClientFactoryTest extends TestCase
      */
     protected $vonageClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize('Vonage\Client');
         $this->vonageClient->getRestUrl()->willReturn('https://rest.nexmo.com');

--- a/test/Account/ClientTest.php
+++ b/test/Account/ClientTest.php
@@ -43,7 +43,7 @@ class ClientTest extends TestCase
      */
     protected $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize('Vonage\Client');
         $this->vonageClient->getRestUrl()->willReturn('https://rest.nexmo.com');

--- a/test/Account/ConfigTest.php
+++ b/test/Account/ConfigTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->config = new Config(
             "https://example.com/webhooks/inbound-sms",

--- a/test/Account/PrefixPriceTest.php
+++ b/test/Account/PrefixPriceTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class PrefixPriceTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
     }
 

--- a/test/Account/SecretCollectionTest.php
+++ b/test/Account/SecretCollectionTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class SecretCollectionTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->secrets = [[
             'id' => 'ad6dc56f-07b5-46e1-a527-85530e625800',

--- a/test/Account/SecretTest.php
+++ b/test/Account/SecretTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class SecretTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->secret = @Secret::fromApi([
             'id' => 'ad6dc56f-07b5-46e1-a527-85530e625800',

--- a/test/Account/SmsPriceTest.php
+++ b/test/Account/SmsPriceTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class SmsPriceTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
     }
 

--- a/test/Application/ApplicationTest.php
+++ b/test/Application/ApplicationTest.php
@@ -22,7 +22,7 @@ class ApplicationTest extends TestCase
      */
     protected $app;
     
-    public function setUp()
+    public function setUp(): void
     {
         $this->app = new Application();
         $this->app->setName('test');

--- a/test/Application/ClientTest.php
+++ b/test/Application/ClientTest.php
@@ -43,7 +43,7 @@ class ClientTest extends TestCase
      */
     protected $applicationClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize('Vonage\Client');
         $this->vonageClient->getApiUrl()->willReturn('http://api.nexmo.com');

--- a/test/Call/CallTest.php
+++ b/test/Call/CallTest.php
@@ -43,7 +43,7 @@ class CallTest extends TestCase
      */
     protected $vonageClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id = '3fd4d839-493e-4485-b2a5-ace527aacff3';
         $this->class = Call::class;

--- a/test/Call/CollectionTest.php
+++ b/test/Call/CollectionTest.php
@@ -40,7 +40,7 @@ class CollectionTest extends TestCase
      */
     protected $collection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize('Vonage\Client');
         $this->vonageClient->getApiUrl()->willReturn('https://api.nexmo.com');

--- a/test/Call/DtmfTest.php
+++ b/test/Call/DtmfTest.php
@@ -38,7 +38,7 @@ class DtmfTest extends TestCase
      */
     protected $vonageClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id = '3fd4d839-493e-4485-b2a5-ace527aacff3';
         $this->class = Dtmf::class;

--- a/test/Call/EventTest.php
+++ b/test/Call/EventTest.php
@@ -18,7 +18,7 @@ class EventTest extends TestCase
 
     protected $entity;
 
-    public function setup()
+    public function setup(): void
     {
         $data = $this->getResponseData(['calls', 'event']);
         $this->entity = @new Event($data);

--- a/test/Call/FilterTest.php
+++ b/test/Call/FilterTest.php
@@ -19,7 +19,7 @@ class FilterTest extends TestCase
      */
     protected $filter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->filter = @new Filter();
     }

--- a/test/Call/StreamTest.php
+++ b/test/Call/StreamTest.php
@@ -38,7 +38,7 @@ class StreamTest extends TestCase
      */
     protected $vonageClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id = '3fd4d839-493e-4485-b2a5-ace527aacff3';
         $this->class = Stream::class;

--- a/test/Call/TalkTest.php
+++ b/test/Call/TalkTest.php
@@ -38,7 +38,7 @@ class TalkTest extends TestCase
      */
     protected $vonageClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id = '3fd4d839-493e-4485-b2a5-ace527aacff3';
         $this->class = Talk::class;

--- a/test/Client/Credentials/ContainerTest.php
+++ b/test/Client/Credentials/ContainerTest.php
@@ -28,7 +28,7 @@ class ContainerTest extends TestCase
     protected $secret;
     protected $keypair;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->basic = new Basic('key', 'secret');
         $this->secret = new SignatureSecret('key', 'secret');

--- a/test/Client/Credentials/KeypairTest.php
+++ b/test/Client/Credentials/KeypairTest.php
@@ -16,7 +16,7 @@ class KeypairTest extends TestCase
     protected $key;
     protected $application = 'c90ddd99-9a5d-455f-8ade-dde4859e590e';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->key = file_get_contents(__DIR__ . '/test.key');
     }

--- a/test/Client/Factory/MapFactoryTest.php
+++ b/test/Client/Factory/MapFactoryTest.php
@@ -24,7 +24,7 @@ class MapFactoryTest extends TestCase
      */
     protected $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = new Client(new Client\Credentials\Basic('key', 'secret'));
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -43,7 +43,7 @@ class ClientTest extends TestCase
     protected $key_credentials;
     protected $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->http         = $this->getMockHttp();
         $this->request      = $this->getRequest();

--- a/test/Conversation/CollectionTest.php
+++ b/test/Conversation/CollectionTest.php
@@ -32,7 +32,7 @@ class CollectionTest extends TestCase
      */
     protected $collection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize(Client::class);
         $this->vonageClient->getApiUrl()->willReturn('https://api.nexmo.com');

--- a/test/Conversion/ClientTest.php
+++ b/test/Conversion/ClientTest.php
@@ -32,7 +32,7 @@ class ClientTest extends TestCase
      */
     protected $accountClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->getMockBuilder('Vonage\Client')->disableOriginalConstructor()->setMethods(['send', 'getApiUrl'])->getMock();
         $this->vonageClient->method('getApiUrl')->will($this->returnValue('https://api.nexmo.com'));

--- a/test/Insights/ClientTest.php
+++ b/test/Insights/ClientTest.php
@@ -37,7 +37,7 @@ class ClientTest extends TestCase
      */
     protected $insightsClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize('Vonage\Client');
         $this->vonageClient->getApiUrl()->willReturn('http://api.nexmo.com');

--- a/test/Message/Callback/ReceiptTest.php
+++ b/test/Message/Callback/ReceiptTest.php
@@ -30,7 +30,7 @@ class ReceiptTest extends TestCase
      */
     protected $receipt;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->receipt = new Receipt($this->data);
     }

--- a/test/Message/ClientTest.php
+++ b/test/Message/ClientTest.php
@@ -38,7 +38,7 @@ class ClientTest extends TestCase
     /**
      * Create the Message API Client, and mock the Vonage Client
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize('Vonage\Client');
         $this->vonageClient->getRestUrl()->willReturn('https://rest.nexmo.com');

--- a/test/Message/FetchedMessageTest.php
+++ b/test/Message/FetchedMessageTest.php
@@ -31,12 +31,12 @@ class FetchedMessageTest extends TestCase
      */
     protected $message;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->message = new \Vonage\Message\Message('02000000D912945A');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->message = null;
     }

--- a/test/Message/MessageCreationTest.php
+++ b/test/Message/MessageCreationTest.php
@@ -23,14 +23,14 @@ class MessageCreationTest extends TestCase
      */
     protected $message;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->message = new \Vonage\Message\Message($this->to, $this->from, [
             'text' => $this->text
         ]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->message = null;
     }

--- a/test/Message/MessageTest.php
+++ b/test/Message/MessageTest.php
@@ -27,14 +27,14 @@ class MessageTest extends TestCase
      */
     protected $message;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->message = new \Vonage\Message\Message($this->to, $this->from, [
             'text' => $this->text
         ]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->message = null;
     }

--- a/test/Message/MultiMessageTest.php
+++ b/test/Message/MultiMessageTest.php
@@ -31,14 +31,14 @@ class MultiMessageTest extends TestCase
      */
     protected $message;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->message = new \Vonage\Message\Message($this->to, $this->from, [
             'text' => $this->text
         ]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->message = null;
     }

--- a/test/Message/ShortcodeTest.php
+++ b/test/Message/ShortcodeTest.php
@@ -15,11 +15,11 @@ use PHPUnit\Framework\TestCase;
 
 class ShortcodeTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 

--- a/test/Network/Number/CallbackTest.php
+++ b/test/Network/Number/CallbackTest.php
@@ -25,7 +25,7 @@ class CallbackTest extends TestCase
      */
     protected $callback;
 
-    public function setup()
+    public function setup(): void
     {
         $this->callback = new Callback($this->data);
     }

--- a/test/Network/Number/ResponseTest.php
+++ b/test/Network/Number/ResponseTest.php
@@ -26,7 +26,7 @@ class ResponseTest extends TestCase
      */
     protected $response;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->response = new Response($this->data);
     }

--- a/test/Numbers/ClientTest.php
+++ b/test/Numbers/ClientTest.php
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
      */
     protected $numberClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize('Vonage\Client');
         $this->vonageClient->getRestUrl()->willReturn('https://rest.nexmo.com');

--- a/test/Numbers/NumberTest.php
+++ b/test/Numbers/NumberTest.php
@@ -20,7 +20,7 @@ class NumberTest extends TestCase
      */
     protected $number;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->number = new Number();
     }

--- a/test/Redact/ClientTest.php
+++ b/test/Redact/ClientTest.php
@@ -33,7 +33,7 @@ class ClientTest extends TestCase
      */
     protected $redact;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize('Vonage\Client');
         $this->vonageClient->getApiUrl()->willReturn('https://api.nexmo.com');

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -19,7 +19,7 @@ class ResponseTest extends TestCase
     protected $json = '{"message-count":"1","messages":[{"status":"returnCode","message-id":"messageId","to":"to","client-ref":"client-ref","remaining-balance":"remaining-balance","message-price":"message-price","network":"network","error-text":"error-message"}]}';
     protected $array;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->response = new Response($this->json);
         $this->array = json_decode($this->json, true);

--- a/test/SMS/ClientTest.php
+++ b/test/SMS/ClientTest.php
@@ -34,7 +34,7 @@ class ClientTest extends TestCase
      */
     protected $smsClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize(vonageClient::class);
         $this->vonageClient->getRestUrl()->willReturn('https://rest.nexmo.com');

--- a/test/User/CollectionTest.php
+++ b/test/User/CollectionTest.php
@@ -32,7 +32,7 @@ class CollectionTest extends TestCase
      */
     protected $collection;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize(Client::class);
         $this->vonageClient->getApiUrl()->willReturn('https://api.nexmo.com');

--- a/test/Verify/ClientTest.php
+++ b/test/Verify/ClientTest.php
@@ -33,7 +33,7 @@ class ClientTest extends TestCase
     /**
      * Create the Message API Client, and mock the Vonage Client
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize('Vonage\Client');
         $this->vonageClient->getApiUrl()->willReturn('https://api.nexmo.com');

--- a/test/Verify/VerificationTest.php
+++ b/test/Verify/VerificationTest.php
@@ -41,7 +41,7 @@ class VerificationTest extends TestCase
     /**
      * Create a basic verification object
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->verification = @new Verification($this->number, $this->brand);
         $this->existing    = new Verification('44a5279b27dd4a638d614d265ad57a77');

--- a/test/Voice/Call/CallTest.php
+++ b/test/Voice/Call/CallTest.php
@@ -20,7 +20,7 @@ class CallTest extends TestCase
     protected $from = '15551112323';
     protected $url = 'http://example.com';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->call = new Call($this->url, $this->to, $this->from);
     }

--- a/test/Voice/ClientTest.php
+++ b/test/Voice/ClientTest.php
@@ -39,7 +39,7 @@ class ClientTest extends TestCase
      */
     protected $voiceClient;
     
-    public function setUp()
+    public function setUp(): void
     {
         $this->vonageClient = $this->prophesize(Client::class);
         $this->vonageClient->getApiUrl()->willReturn('https://api.nexmo.com');

--- a/test/Voice/Message/CallbackTest.php
+++ b/test/Voice/Message/CallbackTest.php
@@ -29,7 +29,7 @@ class CallbackTest extends TestCase
      */
     protected $callback;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->callback = new Callback($this->data);
     }

--- a/test/Voice/Message/MessageTest.php
+++ b/test/Voice/Message/MessageTest.php
@@ -21,7 +21,7 @@ class MessageTest extends TestCase
     protected $to   = '15553331212';
     protected $from = '15554441212';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->message = new Message($this->text, $this->to, $this->from);
     }

--- a/test/Voice/NCCO/Action/ConnectTest.php
+++ b/test/Voice/NCCO/Action/ConnectTest.php
@@ -16,7 +16,7 @@ class ConnectTest extends TestCase
      */
     protected $endpoint;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->endpoint = new Phone('15551231234');
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I've added support for PhP 8, but not PhP 9.
## Description
<!--- Describe your changes in detail -->
I went through every Test PhP and added the necessary changes for PhP 8 to successfully run. Though PhP 9 would deprecate the tests all together.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I find PhP 8 to be more stable and bug free, PhP 7, was claimed by other people to be an unstable mess.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I used the build bot. An upgrade to PhP 8 does not require significant refactoring or changes to code. It is only the tests the had to be changed. I know this due to doing this to other projects as well with no issues.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
PhP 8 has new features and many bug fixes, and as such, is much more stable software wise.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
