### PR TITLE
PHP 8 Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4' ]
-    continue-on-error: ${{ matrix.php == '8.0' }}
+        php: [ '7.2', '7.3', '7.4', '8.0' ]
     name: PHP ${{ matrix.php }} Test
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "laminas/laminas-diactoros": "^2.4",
-    "lcobucci/jwt": "^3.3",
+    "lcobucci/jwt": "^3.4@dev|^4.0@beta",
     "composer/package-versions-deprecated": "^1.11",
     "psr/container": "^1.0",
     "psr/http-client-implementation": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "laminas/laminas-diactoros": "^2.4",
-    "lcobucci/jwt": "^3.4@dev|^4.0@beta",
+    "lcobucci/jwt": "^3.4|^4.0",
     "composer/package-versions-deprecated": "^1.11",
     "psr/container": "^1.0",
     "psr/http-client-implementation": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "vonage/nexmo-bridge": "^0.1.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.16",
     "guzzlehttp/guzzle": ">=6",
     "helmich/phpunit-json-assert": "^3.3",
     "php-http/mock-client": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "helmich/phpunit-json-assert": "^3.3",
     "php-http/mock-client": "^1.4",
     "phpstan/phpstan": "^0.12",
-    "phpunit/phpunit": "^8.5",
+    "phpunit/phpunit": "^8.5|^9.4",
     "roave/security-advisories": "dev-latest",
     "squizlabs/php_codesniffer": "^3.5",
     "softcreatr/jsonpath": "^0.6.4"

--- a/src/Client.php
+++ b/src/Client.php
@@ -205,9 +205,9 @@ class Client
                 static function (
                     int $errno,
                     string $errstr,
-                    string $errfile,
-                    int $errline,
-                    array $errorcontext
+                    string $errfile = null,
+                    int $errline = null,
+                    array $errorcontext = null
                 ) {
                     return true;
                 },
@@ -478,14 +478,14 @@ class Client
             if ($this->needsKeypairAuthentication($request)) {
                 $token = $this->credentials->get(Keypair::class)->generateJwt();
 
-                $request = $request->withHeader('Authorization', 'Bearer ' . $token);
+                $request = $request->withHeader('Authorization', 'Bearer ' . $token->toString());
             } else {
                 $request = self::authRequest($request, $this->credentials->get(Basic::class));
             }
         } elseif ($this->credentials instanceof Keypair) {
             $token = $this->credentials->generateJwt();
 
-            $request = $request->withHeader('Authorization', 'Bearer ' . $token);
+            $request = $request->withHeader('Authorization', 'Bearer ' . $token->toString());
         } elseif ($this->credentials instanceof SignatureSecret) {
             $request = self::signRequest($request, $this->credentials);
         } elseif ($this->credentials instanceof Basic) {

--- a/src/Client/Signature.php
+++ b/src/Client/Signature.php
@@ -65,7 +65,7 @@ class Signature
         $signed = [];
 
         foreach ($this->signed as $key => $value) {
-            $signed[$key] = str_replace(["&", "="], "_", $value);
+            $signed[$key] = str_replace(["&", "="], "_", (string) $value);
         }
 
         //create base string

--- a/src/Entity/CollectionTrait.php
+++ b/src/Entity/CollectionTrait.php
@@ -69,9 +69,9 @@ trait CollectionTrait
      */
     protected $filter;
 
-    abstract public function getCollectionName(): string;
+    abstract public static function getCollectionName(): string;
 
-    abstract public function getCollectionPath(): string;
+    abstract public static function getCollectionPath(): string;
 
     /**
      * @param $data
@@ -84,7 +84,7 @@ trait CollectionTrait
      */
     public function current()
     {
-        return $this->hydrateEntity($this->page['_embedded'][$this->getCollectionName()][$this->current], $this->key());
+        return $this->hydrateEntity($this->page['_embedded'][static::getCollectionName()][$this->current], $this->key());
     }
 
     /**
@@ -103,8 +103,8 @@ trait CollectionTrait
     public function key()
     {
         return
-            $this->page['_embedded'][$this->getCollectionName()][$this->current]['id'] ??
-            $this->page['_embedded'][$this->getCollectionName()][$this->current]['uuid'] ??
+            $this->page['_embedded'][static::getCollectionName()][$this->current]['id'] ??
+            $this->page['_embedded'][static::getCollectionName()][$this->current]['uuid'] ??
             $this->current;
     }
 
@@ -119,12 +119,12 @@ trait CollectionTrait
         }
 
         //all hal collections have an `_embedded` object, we expect there to be a property matching the collection name
-        if (!isset($this->page['_embedded'][$this->getCollectionName()])) {
+        if (!isset($this->page['_embedded'][static::getCollectionName()])) {
             return false;
         }
 
         //if we have a page with no items, we've gone beyond the end of the collection
-        if (!count($this->page['_embedded'][$this->getCollectionName()])) {
+        if (!count($this->page['_embedded'][static::getCollectionName()])) {
             return false;
         }
 
@@ -134,7 +134,7 @@ trait CollectionTrait
         }
 
         //if our current index is past the current page, fetch the next page if possible and reset the index
-        if (!isset($this->page['_embedded'][$this->getCollectionName()][$this->current])) {
+        if (!isset($this->page['_embedded'][static::getCollectionName()][$this->current])) {
             if (isset($this->page['_links']['next'])) {
                 $this->fetchPage($this->page['_links']['next']['href']);
                 $this->current = 0;
@@ -153,7 +153,7 @@ trait CollectionTrait
      */
     public function rewind(): void
     {
-        $this->fetchPage($this->getCollectionPath());
+        $this->fetchPage(static::getCollectionPath());
     }
 
     /**

--- a/test/Client/Credentials/KeypairTest.php
+++ b/test/Client/Credentials/KeypairTest.php
@@ -57,7 +57,7 @@ class KeypairTest extends TestCase
         $credentials = new Keypair($this->key, $this->application);
 
         //could use the JWT object, but hope to remove as a dependency
-        $jwt = (string)$credentials->generateJwt();
+        $jwt = (string)$credentials->generateJwt()->toString();
 
         [$header, $payload] = $this->decodeJWT($jwt);
 
@@ -84,7 +84,7 @@ class KeypairTest extends TestCase
         ];
 
         $jwt = $credentials->generateJwt($claims);
-        [, $payload] = $this->decodeJWT($jwt);
+        [, $payload] = $this->decodeJWT($jwt->toString());
 
         $this->assertArrayHasKey('arbitrary', $payload);
         $this->assertEquals($claims['arbitrary'], $payload['arbitrary']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR provides PHP 8 support for this library. Currently in draft until `lcobucci/jwt` has been patched.

## Motivation and Context

We'll need this to make sure we can tag and install `nexmo/nexmo-laravel` with PHP 8 support based on this PR: https://github.com/Nexmo/nexmo-laravel/pull/51

This is needed to provide PHP 8 support for Nexmo Notification Channel in Laravel: https://github.com/laravel/nexmo-notification-channel/pull/39

PHP 8 is released on Thursday.

## How Has This Been Tested?
I've updated the Github Actions workflow to make sure the test suite runs on PHP 8 as well.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
