### PR TITLE
Uses the Versions package to better determine the Guzzle version

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -124,14 +124,18 @@ class Client
         if (is_null($client)) {
             // Since the user did not pass a client, try and make a client
             // using the Guzzle 6 adapter or Guzzle 7 (depending on availability)
-            /** @noinspection ClassConstantCanBeUsedInspection */
-            if (class_exists('\GuzzleHttp\Client')) {
-                $client = new \GuzzleHttp\Client();
-            } elseif (class_exists('\Http\Adapter\Guzzle6\Client')) {
+            list($guzzleVersion) = explode('@', Versions::getVersion('guzzlehttp/guzzle'), 1);
+            $guzzleVersion = (float) $guzzleVersion;
+
+            if ($guzzleVersion >= 6.0 && $guzzleVersion < 7) {
                 /** @noinspection CallableParameterUseCaseInTypeContextInspection */
                 /** @noinspection PhpUndefinedNamespaceInspection */
                 /** @noinspection PhpUndefinedClassInspection */
                 $client = new \Http\Adapter\Guzzle6\Client();
+            }
+
+            if ($guzzleVersion >= 7.0 && $guzzleVersion < 8.0) {
+                $client = new \GuzzleHttp\Client();
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This changes from using the class names to determine the guzzle version to using the actual version number reported in Composer. This allows us to determine with better accuracy which version of Guzzle is available so we can make the correct wrapper.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since we support both Guzzle 6 and Guzzle 7, and Guzzle 6 needs a wrapper, we need to have a good consistent way of checking this. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by forcing Guzzle 6 with the wrapper and 7 in various demo instances to make sure detection was working. Example composer setups are below. Each test successfully sent the SMS message using the `send-sms.php` code snippet code.

### Guzzle 6 Test
```console
$  composer require guzzlehttp/guzzle:^6.0 php-http/guzzle6-adapter vonage/client-core:dev-better-guzzle-detection@dev
$  php test.php
The message was sent successfully
```

### Guzzle 7 Test
```console
$  composer require guzzlehttp/guzzle:^7.0 vonage/client-core:dev-better-guzzle-detection@dev
$  php test.php
The message was sent successfully
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
