### PR TITLE
Added support for PSR-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,7 +819,7 @@ See the [Packagist page for client-implementation](https://packagist.org/provide
 Our client library has support for logging the request and response for debugging via PSR-3 compatible logging mechanisms. If the `debug` option is passed into the client and a PSR-3 compatible logger is set in our client's service factory, we will use the logger for debugging purposes.
 
 ```php
-$client = new \Vonage\Client(new Basic('abcd1234', 's3cr3tk3y'), ['debug' => true]);
+$client = new \Vonage\Client(new \Vonage\Client\Credentials\Basic('abcd1234', 's3cr3tk3y'), ['debug' => true]);
 $logger = new \Monolog\Logger('test');
 $logger->pushHandler(new \Monolog\Handler\StreamHandler(__DIR__ . '/log.txt', \Monolog\Logger::DEBUG));
 $client->getFactory()->set(\PSR\Log\LoggerInterface::class, $logger);
@@ -840,4 +840,3 @@ This library is actively developed, and we love to hear from you! Please feel fr
 [spec]: https://github.com/Nexmo/client-library-specification
 [issues]: https://github.com/Vonage/vonage-php-core/issues
 [pulls]: https://github.com/Vonage/vonage-php-core/pulls
-

--- a/README.md
+++ b/README.md
@@ -814,8 +814,20 @@ If you have a conflicting package installation that cannot co-exist with our rec
 
 See the [Packagist page for client-implementation](https://packagist.org/providers/php-http/client-implementation) for options.
 
-Contributing
-------------
+### Enabling Request/Response Logging
+
+Our client library has support for logging the request and response for debugging via PSR-3 compatible logging mechanisms. If the `debug` option is passed into the client and a PSR-3 compatible logger is set in our client's service factory, we will use the logger for debugging purposes.
+
+```php
+$client = new \Vonage\Client(new Basic('abcd1234', 's3cr3tk3y'), ['debug' => true]);
+$logger = new \Monolog\Logger('test');
+$logger->pushHandler(new \Monolog\Handler\StreamHandler(__DIR__ . '/log.txt', \Monolog\Logger::DEBUG));
+$client->getFactory()->set(\PSR\Log\LoggerInterface::class, $logger);
+```
+
+**ENABLING DEBUGING LOGGING HAS THE POTENTIAL FOR LOGGING SENSITIVE INFORMATION, DO NOT ENABLE IN PRODUCTION**
+
+## Contributing
 
 This library is actively developed, and we love to hear from you! Please feel free to [create an issue][issues] or [open a pull request][pulls] with your questions, comments, suggestions and feedback.
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "composer/package-versions-deprecated": "^1.11",
     "psr/container": "^1.0",
     "psr/http-client-implementation": "^1.0",
-    "vonage/nexmo-bridge": "^0.1.0"
+    "vonage/nexmo-bridge": "^0.1.0",
+    "psr/log": "^1.1"
   },
   "require-dev": {
     "guzzlehttp/guzzle": ">=6",

--- a/src/Client/Factory/MapFactory.php
+++ b/src/Client/Factory/MapFactory.php
@@ -12,8 +12,10 @@ declare(strict_types=1);
 namespace Vonage\Client\Factory;
 
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Vonage\Client;
+use Vonage\Logger\LoggerAwareInterface;
 
 use function is_callable;
 use function sprintf;
@@ -120,11 +122,18 @@ class MapFactory implements FactoryInterface, ContainerInterface
             $instance->setClient($this->client);
         }
 
+        if ($instance instanceof LoggerAwareInterface && $this->has(LoggerInterface::class)) {
+            $instance->setLogger($this->get(LoggerInterface::class));
+        }
+
         return $instance;
     }
 
     public function set($key, $value): void
     {
         $this->map[$key] = $value;
+        if (!is_callable($value)) {
+            $this->cache[$key] = $value;
+        }
     }
 }

--- a/src/Logger/LoggerAwareInterface.php
+++ b/src/Logger/LoggerAwareInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Vonage\Logger;
+
+use Psr\Log\LoggerInterface;
+
+interface LoggerAwareInterface
+{
+    public function getLogger(): ?LoggerInterface;
+
+    /**
+     * @param string|int $level Level of message that we are logging
+     * @param array<mixed> $context Additional information for context
+     */
+    public function log($level, string $message, array $context = []): void;
+
+    /**
+     * @return self
+     */
+    public function setLogger(LoggerInterface $logger);
+}

--- a/src/Logger/LoggerTrait.php
+++ b/src/Logger/LoggerTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Vonage\Logger;
+
+use Psr\Log\LoggerInterface;
+
+trait LoggerTrait
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    public function getLogger(): ?LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    /**
+     * @param string|int $level Level of message that we are logging
+     * @param array<mixed> $context Additional information for context
+     */
+    public function log($level, string $message, array $context = []): void
+    {
+        $logger = $this->getLogger();
+        if ($logger) {
+            $logger->log($level, $message, $context);
+        }
+    }
+
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+}

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -19,6 +19,7 @@ use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Vonage\Client;
 use Vonage\Client\Credentials\Basic;
@@ -662,6 +663,21 @@ class ClientTest extends TestCase
 
         $this->assertRequestMethod("DELETE", $request);
         $this->assertRequestBodyIsEmpty($request);
+    }
+
+    public function testLoggerIsNullWhenNotSet(): void
+    {
+        $client = new Client($this->basic_credentials, [], $this->http);
+        $this->assertNull($client->getLogger());
+    }
+
+    public function testCanGetLoggerWhenOneIsSet(): void
+    {
+        $client = new Client($this->basic_credentials, [], $this->http);
+        $logger = $this->prophesize(LoggerInterface::class);
+        $client->getFactory()->set(LoggerInterface::class, $logger->reveal());
+
+        $this->assertNotNull($client->getLogger());
     }
 
     public function genericDeleteProvider(): array

--- a/test/Logger/LoggerTraitTest.php
+++ b/test/Logger/LoggerTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace VonageTest\Logger;
+
+use Psr\Log\LoggerInterface;
+use Vonage\Logger\LoggerTrait;
+use PHPUnit\Framework\TestCase;
+
+class LoggerTraitTest extends TestCase
+{
+    public function testCanSetAndGetLogger()
+    {
+        /** @var LoggerTrait $trait */
+        $trait = $this->getMockForTrait(LoggerTrait::class);
+        $logger = $this->prophesize(LoggerInterface::class)->reveal();
+        $trait->setLogger($logger);
+
+        $this->assertSame($logger, $trait->getLogger());
+    }
+
+    public function testNoLoggerReturnsNull()
+    {
+        /** @var LoggerTrait $trait */
+        $trait = $this->getMockForTrait(LoggerTrait::class);
+
+        $this->assertNull($trait->getLogger());
+    }
+
+    public function testCanLogMessageWithLogger()
+    {
+        /** @var LoggerTrait $trait */
+        $trait = $this->getMockForTrait(LoggerTrait::class);
+        $logger = $this->prophesize(LoggerInterface::class)->reveal();
+        $trait->setLogger($logger);
+
+        $this->assertNull($trait->log('debug', 'This is a message'));
+    }
+
+    public function testLoggingAcceptsMessageWithLogger()
+    {
+        /** @var LoggerTrait $trait */
+        $trait = $this->getMockForTrait(LoggerTrait::class);
+
+        $this->assertNull($trait->log('debug', 'This is a message'));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds support for PSR-3, which enables standardized logging. It also allows enabling a "debug" flag that will log out a Request and associated Response if a logger is set at DEBUG level.

This does _not_ provide a logger itself, just allows a PSR-3 compatible logger to be passed in via the MapFactory and setting something to the `PSR\Log\LoggerInterface` key. The user is responsible for providing the logger that the client will use.

This also allows us to add logging capabilities to the individual APIs as well later down the line.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Logging is a standard thing most applications do. Users can now get basic logging from our system. Request/Response logging is available as it is the most common debugging information that is needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test scripts using Monolog as a logging solution.

## Example Output or Screenshots (if appropriate):
To enable logging, you will need to enable the new `debug` flag as well as pass a PSR-3 compliant logger such as Monolog (not shipped with our library):

```php
$client = new Vonage\Client(new Basic('abcd1234', 's3cr3tk3y'), ['debug' => true]);
$logger = new Monolog\Logger('test');
$logger->pushHandler(new StreamHandler(__DIR__ . '/log.txt'));
$client->getFactory()->set(LoggerInterface::class, $logger);
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
