### PR TITLE
Added ability to set DLT information

### DIFF
--- a/src/SMS/Message/SMS.php
+++ b/src/SMS/Message/SMS.php
@@ -20,6 +20,16 @@ class SMS extends OutboundMessage
     /**
      * @var string
      */
+    protected $contentId;
+
+    /**
+     * @var string
+     */
+    protected $entityId;
+
+    /**
+     * @var string
+     */
     protected $message;
 
     /**
@@ -38,12 +48,42 @@ class SMS extends OutboundMessage
         $this->message = $message;
     }
 
+    public function getContentId(): string
+    {
+        return $this->contentId;
+    }
+
+    public function getEntityId(): string
+    {
+        return $this->entityId;
+    }
+
+    public function setContentId(string $id): self
+    {
+        $this->contentId = $id;
+        return $this;
+    }
+
+    public function setEntityId(string $id): self
+    {
+        $this->entityId = $id;
+        return $this;
+    }
+
     /**
-     * @return mixed
+     * @return array<mixed>
      */
     public function toArray(): array
     {
         $data = ['text' => $this->getMessage()];
+        if (!empty($this->entityId)) {
+            $data['entity-id'] = $this->entityId;
+        }
+
+        if (!empty($this->contentId)) {
+            $data['content-id'] = $this->contentId;
+        }
+
         $data = $this->appendUniversalOptions($data);
 
         return $data;
@@ -52,5 +92,13 @@ class SMS extends OutboundMessage
     public function getMessage(): string
     {
         return $this->message;
+    }
+
+    public function enableDLT(string $entityId, string $templateId): self
+    {
+        $this->entityId = $entityId;
+        $this->contentId = $templateId;
+
+        return $this;
     }
 }

--- a/test/SMS/Message/SMSTest.php
+++ b/test/SMS/Message/SMSTest.php
@@ -90,4 +90,77 @@ class SMSTest extends TestCase
         (new SMS('447700900000', '16105551212', 'Test Message'))
             ->setClientRef('This is a really long client ref and should throw an exception');
     }
+
+    public function testCanSetEntityId()
+    {
+        $sms = new SMS('447700900000', '16105551212', 'Test Message');
+        $sms->setEntityId('abcd');
+
+        $expected = [
+            'text' => 'Test Message',
+            'entity-id' => 'abcd',
+            'to' => '447700900000',
+            'from' => '16105551212',
+            'type' => 'text',
+            'ttl' => 259200000,
+            'status-report-req' => 1,
+        ];
+
+        $this->assertSame($expected, $sms->toArray());
+        $this->assertSame($expected['entity-id'], $sms->getEntityId());
+    }
+
+    public function testCanSetContentId()
+    {
+        $sms = new SMS('447700900000', '16105551212', 'Test Message');
+        $sms->setContentId('1234');
+
+        $expected = [
+            'text' => 'Test Message',
+            'content-id' => '1234',
+            'to' => '447700900000',
+            'from' => '16105551212',
+            'type' => 'text',
+            'ttl' => 259200000,
+            'status-report-req' => 1,
+        ];
+
+        $this->assertSame($expected, $sms->toArray());
+        $this->assertSame($expected['content-id'], $sms->getContentId());
+    }
+
+    public function testDLTInfoAppearsInRequest()
+    {
+        $sms = new SMS('447700900000', '16105551212', 'Test Message');
+        $sms->enableDLT('abcd', '1234');
+
+        $expected = [
+            'text' => 'Test Message',
+            'entity-id' => 'abcd',
+            'content-id' => '1234',
+            'to' => '447700900000',
+            'from' => '16105551212',
+            'type' => 'text',
+            'ttl' => 259200000,
+            'status-report-req' => 1,
+        ];
+
+        $this->assertSame($expected, $sms->toArray());
+    }
+
+    public function testDLTInfoDoesNotAppearsWhenNotSet()
+    {
+        $sms = new SMS('447700900000', '16105551212', 'Test Message');
+
+        $expected = [
+            'text' => 'Test Message',
+            'to' => '447700900000',
+            'from' => '16105551212',
+            'type' => 'text',
+            'ttl' => 259200000,
+            'status-report-req' => 1,
+        ];
+
+        $this->assertSame($expected, $sms->toArray());
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a new `enableDLT()` method to SMS messages to allow Indian DLT messages to be sent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To help users conform to the new Indian SMS regulations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested via unit tests to make sure it conforms to the API spec, and tested with a US number to make sure nothing blew up. Unfortunately I could not test against a registered Indian number.

## Example / Screen Shots
```php
$sms = new SMS('15556661008', '15558880000', 'Testing DLT');
$sms->enableDLT('abcd', '1234');
$response = $client->sms()->send($sms);
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
