### PR TITLE
Added detail field to VAPI event object

### DIFF
--- a/src/Voice/Webhook/Event.php
+++ b/src/Voice/Webhook/Event.php
@@ -41,6 +41,11 @@ class Event
     /**
      * @var string
      */
+    protected $detail;
+
+    /**
+     * @var string
+     */
     protected $direction;
 
     /**
@@ -122,11 +127,22 @@ class Event
         if (array_key_exists('end_time', $event)) {
             $this->endTime = new DateTimeImmutable($event['end_time']);
         }
+
+        $this->detail = $event['detail'] ?? null;
     }
 
     public function getConversationUuid(): string
     {
         return $this->conversationUuid;
+    }
+
+    /**
+     * Returns additional details on the event, if available
+     * Not all events contain this field, so it may be null.
+     */
+    public function getDetail(): ?string
+    {
+        return $this->detail;
     }
 
     public function getDirection(): string

--- a/test/Voice/Webhook/FactoryTest.php
+++ b/test/Voice/Webhook/FactoryTest.php
@@ -277,6 +277,30 @@ class FactoryTest extends TestCase
         Factory::createFromArray(['foo' => 'bar']);
     }
 
+    public function testEventWithDetailIsDeserializedProperly()
+    {
+        $request = $this->getRequest('event-post-failed');
+        $expected = json_decode($this->getRequest('event-post-failed')->getBody()->getContents(), true);
+
+        /** @var Event $event */
+        $event = Factory::createFromRequest($request);
+
+        $this->assertInstanceOf(Event::class, $event);
+        $this->assertSame($expected['detail'], $event->getDetail());
+    }
+
+    public function testEventWithoutDetailIsDeserializedProperly()
+    {
+        $request = $this->getRequest('event-post-ringing');
+        $expected = json_decode($this->getRequest('event-post-ringing')->getBody()->getContents(), true);
+
+        /** @var Event $event */
+        $event = Factory::createFromRequest($request);
+
+        $this->assertInstanceOf(Event::class, $event);
+        $this->assertNull($event->getDetail());
+    }
+
     public function getRequest(string $requestName): ServerRequest
     {
         $text = file_get_contents(__DIR__ . '/../requests/' . $requestName . '.txt');

--- a/test/Voice/requests/event-post-failed.txt
+++ b/test/Voice/requests/event-post-failed.txt
@@ -1,0 +1,9 @@
+POST /webhooks/event HTTP/1.1
+Content-Type: application/json
+Content-Length: 239
+User-Agent: Apache-HttpAsyncClient/4.1 (Java/1.8.0_66)
+Host: 82b25eb35b96.ngrok.io
+Cache-Control: max-age=259200
+X-Forwarded-For: 169.63.86.174
+
+{"headers":{},"from":"14845552121","to":"16105553939","uuid":"0A0000000123ABCD1","conversation_uuid":"CON-2541d01c-253e-48be-a8e0-da4bbe4c3722","status":"failed","detail":"cannot_route","direction":"outbound","timestamp":"2020-07-01T20:45:34.796Z"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allows the `detail` field to be properly deserialized and accessed if it's part of an event.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This field now appears on some events, so should be made available. Otherwise this will just return null.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit testing. I was not able to generate the new events using a US number so crafted a webhook response based on the API spec.

## Example Output or Screenshots (if appropriate):
```php
// If the webhook is an Event with a detail key:
$event = Factory::createFromRequest($request);
echo $event->getDetail();
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
