### PR TITLE
Moved Secrets to own client

### DIFF
--- a/src/Account/Client.php
+++ b/src/Account/Client.php
@@ -283,12 +283,15 @@ class Client implements ClientAwareInterface, APIClient
     }
 
     /**
+     * @deprecated use the Vonage\Secrets\Client::list method
+     *
      * @throws ClientExceptionInterface
      * @throws ClientException\Exception
      * @throws InvalidResponseException
      */
     public function listSecrets(string $apiKey): SecretCollection
     {
+        trigger_error('Vonage\Account\Client::listSecrets is deprecated, please use the Vonage\Secrets\Client::list method', E_USER_DEPRECATED);
         $api = $this->getSecretsAPI();
 
         $data = $api->get($apiKey . '/secrets');
@@ -296,12 +299,15 @@ class Client implements ClientAwareInterface, APIClient
     }
 
     /**
+     * @deprecated use the Vonage\Secrets\Client::get method
+     *
      * @throws ClientExceptionInterface
      * @throws ClientException\Exception
      * @throws InvalidResponseException
      */
     public function getSecret(string $apiKey, string $secretId): Secret
     {
+        trigger_error('Vonage\Account\Client::getSecret is deprecated, please use the Vonage\Secrets\Client::get method', E_USER_DEPRECATED);
         $api = $this->getSecretsAPI();
 
         $data = $api->get($apiKey . '/secrets/' . $secretId);
@@ -311,6 +317,8 @@ class Client implements ClientAwareInterface, APIClient
     /**
      * Create a new account secret
      *
+     * @deprecated use the Vonage\Secrets\Client::create method
+     *
      * @throws ClientExceptionInterface
      * @throws ClientRequestException
      * @throws ClientException\Exception
@@ -319,6 +327,7 @@ class Client implements ClientAwareInterface, APIClient
      */
     public function createSecret(string $apiKey, string $newSecret): Secret
     {
+        trigger_error('Vonage\Account\Client::createSecret is deprecated, please use the Vonage\Secrets\Client::create method', E_USER_DEPRECATED);
         $api = $this->getSecretsAPI();
         $api->setBaseUri('/accounts/' . $apiKey . '/secrets');
 
@@ -345,11 +354,14 @@ class Client implements ClientAwareInterface, APIClient
     }
 
     /**
+     * @deprecated use the Vonage\Secrets\Client::revoke method
+     *
      * @throws ClientExceptionInterface
      * @throws ClientException\Exception
      */
     public function deleteSecret(string $apiKey, string $secretId): void
     {
+        trigger_error('Vonage\Account\Client::deleteSecret is deprecated, please use the Vonage\Secrets\Client::revoke method', E_USER_DEPRECATED);
         $api = $this->getSecretsAPI();
         $api->setBaseUri('/accounts/' . $apiKey . '/secrets');
         $api->delete($secretId);

--- a/src/Account/Secret.php
+++ b/src/Account/Secret.php
@@ -18,6 +18,9 @@ use Vonage\InvalidResponseException;
 use function get_class;
 use function trigger_error;
 
+/**
+ * @deprecated Use the Vonage\Secrets\Secret object instead
+ */
 class Secret implements ArrayAccess
 {
     protected $data;

--- a/src/Client.php
+++ b/src/Client.php
@@ -44,6 +44,7 @@ use Vonage\Insights\ClientFactory as InsightsClientFactory;
 use Vonage\Message\Client as MessageClient;
 use Vonage\Numbers\ClientFactory as NumbersClientFactory;
 use Vonage\Redact\ClientFactory as RedactClientFactory;
+use Vonage\Secrets\ClientFactory as SecretsClientFactory;
 use Vonage\SMS\ClientFactory as SMSClientFactory;
 use Vonage\User\Collection as UserCollection;
 use Vonage\Verify\ClientFactory as VerifyClientFactory;
@@ -79,6 +80,7 @@ use function unserialize;
  * @method Insights\Client insights()
  * @method Numbers\Client numbers()
  * @method Redact\Client redact()
+ * @method Secrets\Client secrets()
  * @method SMS\Client sms()
  * @method Verify\Client  verify()
  * @method Voice\Client voice()
@@ -192,6 +194,7 @@ class Client
                     'insights' => InsightsClientFactory::class,
                     'numbers' => NumbersClientFactory::class,
                     'redact' => RedactClientFactory::class,
+                    'secrets' => SecretsClientFactory::class,
                     'sms' => SMSClientFactory::class,
                     'verify' => VerifyClientFactory::class,
                     'voice' => VoiceClientFactory::class,

--- a/src/Client/Factory/FactoryInterface.php
+++ b/src/Client/Factory/FactoryInterface.php
@@ -22,4 +22,6 @@ interface FactoryInterface
     public function hasApi(string $api): bool;
 
     public function getApi(string $api);
+
+    public function make(string $key);
 }

--- a/src/Secrets/Client.php
+++ b/src/Secrets/Client.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Vonage\Secrets;
+
+use Vonage\Client\APIClient;
+use Vonage\Client\APIResource;
+use Vonage\Entity\Hydrator\ArrayHydrator;
+use Vonage\Entity\IterableAPICollection;
+
+class Client implements APIClient
+{
+    /**
+     * @var APIResource
+     */
+    protected $api;
+
+    public function __construct(APIResource $api)
+    {
+        $this->api = $api;
+    }
+
+    public function getAPIResource(): APIResource
+    {
+        return $this->api;
+    }
+
+    public function get(string $accountId, string $id): Secret
+    {
+        $data = $this->api->get("${accountId}/secrets/${id}");
+
+        return new Secret($data);
+    }
+
+    public function list(string $accountId): IterableAPICollection
+    {
+        $collection = $this->api->search(null, "/accounts/${accountId}/secrets");
+        $hydrator = new ArrayHydrator();
+        $hydrator->setPrototype(new Secret());
+        $collection->setHydrator($hydrator);
+
+        return $collection;
+    }
+
+    public function create(string $accountId, string $secret): Secret
+    {
+        $response = $this->api->create(['secret' => $secret], "/${accountId}/secrets");
+        return new Secret($response);
+    }
+
+    public function revoke(string $accountId, string $id)
+    {
+        $this->api->delete("${accountId}/secrets/${id}");
+    }
+}

--- a/src/Secrets/ClientFactory.php
+++ b/src/Secrets/ClientFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Vonage Client Library for PHP
+ *
+ * @copyright Copyright (c) 2016-2020 Vonage, Inc. (http://vonage.com)
+ * @license https://github.com/Vonage/vonage-php-sdk-core/blob/master/LICENSE.txt Apache License 2.0
+ */
+
+declare(strict_types=1);
+
+namespace Vonage\Secrets;
+
+use Vonage\Client\APIResource;
+use Vonage\Client\Factory\FactoryInterface;
+
+class ClientFactory
+{
+    public function __invoke(FactoryInterface $container): Client
+    {
+        $api = $container->make(APIResource::class);
+        $api->setBaseUri('/accounts')
+            ->setCollectionName('secrets');
+
+        return new Client($api);
+    }
+}

--- a/src/Secrets/Secret.php
+++ b/src/Secrets/Secret.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Vonage\Secrets;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Vonage\Entity\Hydrator\ArrayHydrateInterface;
+
+class Secret implements ArrayHydrateInterface
+{
+    /**
+     * @var DateTimeImmutable
+     */
+    protected $createdAt;
+
+    /**
+     * @var string
+     */
+    protected $id;
+
+    public function __construct(array $data = [])
+    {
+        if (!empty($data)) {
+            $this->fromArray($data);
+        }
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCreatedAt(): DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function fromArray(array $data)
+    {
+        $this->id = $data['id'];
+        $this->createdAt = new DateTimeImmutable($data['created_at']);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'created_at' => $this->createdAt->format('Y-m-d\TH:i:s\Z'),
+        ];
+    }
+}

--- a/test/Account/ClientTest.php
+++ b/test/Account/ClientTest.php
@@ -455,7 +455,7 @@ class ClientTest extends TestCase
             return true;
         }))->shouldBeCalledTimes(1)->willReturn($this->getResponse('secret-management/list'));
 
-        $this->accountClient->listSecrets('abcd1234');
+        @$this->accountClient->listSecrets('abcd1234');
     }
 
     /**
@@ -471,7 +471,7 @@ class ClientTest extends TestCase
             Argument::any()
         )->willReturn($this->getGenericResponse('500', 500));
 
-        $this->accountClient->listSecrets('abcd1234');
+        @$this->accountClient->listSecrets('abcd1234');
     }
 
     /**
@@ -487,7 +487,7 @@ class ClientTest extends TestCase
             Argument::any()
         )->willReturn($this->getGenericResponse('401', 401));
 
-        $this->accountClient->listSecrets('abcd1234');
+        @$this->accountClient->listSecrets('abcd1234');
     }
 
     /**
@@ -507,7 +507,7 @@ class ClientTest extends TestCase
             return true;
         }))->shouldBeCalledTimes(1)->willReturn($this->getResponse('secret-management/get'));
 
-        $this->accountClient->getSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
+        @$this->accountClient->getSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
     }
 
     /**
@@ -523,7 +523,7 @@ class ClientTest extends TestCase
             Argument::any()
         )->willReturn($this->getGenericResponse('500', 500));
 
-        $this->accountClient->getSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
+        @$this->accountClient->getSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
     }
 
     /**
@@ -539,7 +539,7 @@ class ClientTest extends TestCase
             Argument::any()
         )->willReturn($this->getGenericResponse('401', 401));
 
-        $this->accountClient->getSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
+        @$this->accountClient->getSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
     }
 
     /**
@@ -558,7 +558,7 @@ class ClientTest extends TestCase
             return true;
         }))->shouldBeCalledTimes(1)->willReturn($this->getResponse('secret-management/create'));
 
-        $this->accountClient->createSecret('abcd1234', 'example-4PI-secret');
+        @$this->accountClient->createSecret('abcd1234', 'example-4PI-secret');
     }
 
     /**
@@ -576,7 +576,7 @@ class ClientTest extends TestCase
             Argument::any()
         )->willReturn($this->getGenericResponse('500', 500));
 
-        $this->accountClient->createSecret('abcd1234', 'example-4PI-secret');
+        @$this->accountClient->createSecret('abcd1234', 'example-4PI-secret');
     }
 
     /**
@@ -592,7 +592,7 @@ class ClientTest extends TestCase
 
         $this->vonageClient->send(Argument::any())->willReturn($this->getGenericResponse('401', 401));
 
-        $this->accountClient->createSecret('abcd1234', 'example-4PI-secret');
+        @$this->accountClient->createSecret('abcd1234', 'example-4PI-secret');
     }
 
     /**
@@ -606,12 +606,12 @@ class ClientTest extends TestCase
         try {
             $this->vonageClient->send(Argument::any())
                 ->willReturn($this->getResponse('secret-management/create-validation', 400));
-            $this->accountClient->createSecret('abcd1234', 'example-4PI-secret');
+            @$this->accountClient->createSecret('abcd1234', 'example-4PI-secret');
         } catch (ValidationException $e) {
             $this->assertEquals(
                 'Bad Request: The request failed due to validation errors. ' .
-                'See https://developer.nexmo.com/api-errors/account/secret-management#validation ' .
-                'for more information',
+                    'See https://developer.nexmo.com/api-errors/account/secret-management#validation ' .
+                    'for more information',
                 $e->getMessage()
             );
             $this->assertEquals(
@@ -642,7 +642,7 @@ class ClientTest extends TestCase
             return true;
         }))->shouldBeCalledTimes(1)->willReturn($this->getResponse('secret-management/delete'));
 
-        $this->accountClient->deleteSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
+        @$this->accountClient->deleteSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
     }
 
     /**
@@ -653,7 +653,7 @@ class ClientTest extends TestCase
     {
         $this->expectException(ClientException\Server::class);
         $this->vonageClient->send(Argument::any())->willReturn($this->getGenericResponse('500', 500));
-        $this->accountClient->deleteSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
+        @$this->accountClient->deleteSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
     }
 
     /**
@@ -664,7 +664,7 @@ class ClientTest extends TestCase
     {
         $this->expectException(ClientException\Request::class);
         $this->vonageClient->send(Argument::any())->willReturn($this->getGenericResponse('401', 401));
-        $this->accountClient->deleteSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
+        @$this->accountClient->deleteSecret('abcd1234', 'ad6dc56f-07b5-46e1-a527-85530e625800');
     }
 
     /**

--- a/test/HTTPTestTrait.php
+++ b/test/HTTPTestTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace VonageTest;
+
+use Laminas\Diactoros\Response;
+
+trait HTTPTestTrait
+{
+    use Psr7AssertionTrait;
+
+    /**
+     * Get the API response we'd expect for a call to the API.
+     */
+    protected function getResponse(string $type = 'success', int $status = 200): Response
+    {
+        return new Response(fopen($this->responsesDir . '/' . $type . '.json', 'rb'), $status);
+    }
+}

--- a/test/Secrets/ClientTest.php
+++ b/test/Secrets/ClientTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace VonageTest\Secrets;
+
+use DateTimeInterface;
+use Prophecy\Argument;
+use Vonage\Secrets\Client;
+use Vonage\Secrets\Secret;
+use VonageTest\HTTPTestTrait;
+use Vonage\Client\APIResource;
+use PHPUnit\Framework\TestCase;
+use Vonage\Client as VonageClient;
+use Psr\Http\Message\RequestInterface;
+
+class ClientTest extends TestCase
+{
+    use HTTPTestTrait;
+
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    protected $responsesDir = __DIR__ . '/responses';
+
+    protected $vonage;
+
+    public function setUp(): void
+    {
+        $this->vonage = $this->prophesize(VonageClient::class);
+        $this->vonage->getRestUrl()->willReturn('https://rest.nexmo.com');
+        $this->vonage->getApiUrl()->willReturn('https://api.nexmo.com');
+
+        $api = new APIResource();
+        $api->setClient($this->vonage->reveal())
+            ->setBaseUri('/accounts')
+            ->setCollectionName('secrets');
+
+        $this->client = new Client($api);
+    }
+
+    public function testListAllSecrets()
+    {
+        $this->vonage->send(Argument::that(function (RequestInterface $request) {
+            $this->assertRequestUrl('api.nexmo.com', '/accounts/abcd123/secrets', 'GET', $request);
+            return true;
+        }))->willReturn($this->getResponse('list', 200));
+
+        $response = $this->client->list('abcd123');
+
+        $this->assertCount(2, $response);
+        foreach ($response as $i => $secret) {
+            $this->assertInstanceOf(Secret::class, $secret);
+            $this->assertSame($i, $secret->getId());
+        }
+    }
+
+    public function testGetSecret()
+    {
+        $this->vonage->send(Argument::that(function (RequestInterface $request) {
+            $this->assertRequestUrl('api.nexmo.com', '/accounts/abcd123/secrets/105abf14-aa00-45a3-9d27-dd19c5920f2c', 'GET', $request);
+            return true;
+        }))->willReturn($this->getResponse('single', 200));
+
+        $secret = $this->client->get('abcd123', '105abf14-aa00-45a3-9d27-dd19c5920f2c');
+
+        $this->assertSame('105abf14-aa00-45a3-9d27-dd19c5920f2c', $secret->getId());
+        $this->assertSame('2020-09-08T21:54:14Z', $secret->getCreatedAt()->format('Y-m-d\TH:i:s\Z'));
+    }
+
+    public function testRevokeSecret()
+    {
+        $this->vonage->send(Argument::that(function (RequestInterface $request) {
+            $this->assertRequestUrl('api.nexmo.com', '/accounts/abcd123/secrets/105abf14-aa00-45a3-9d27-dd19c5920f2c', 'DELETE', $request);
+            return true;
+        }))->willReturn($this->getResponse('empty', 204));
+
+        $secret = $this->client->revoke('abcd123', '105abf14-aa00-45a3-9d27-dd19c5920f2c');
+    }
+
+    public function testCreateSecret()
+    {
+        $this->vonage->send(Argument::that(function (RequestInterface $request) {
+            $this->assertRequestUrl('api.nexmo.com', '/accounts/abcd123/secrets', 'POST', $request);
+            return true;
+        }))->willReturn($this->getResponse('new', 204));
+
+        $secret = $this->client->create('abcd123', '105abf14-aa00-45a3-9d27-dd19c5920f2c');
+
+        $this->assertSame('527ffe03-dfba-46c4-9b40-da5cbefb22c4', $secret->getId());
+        $this->assertSame('2020-09-08T21:54:14Z', $secret->getCreatedAt()->format('Y-m-d\TH:i:s\Z'));
+    }
+}

--- a/test/Secrets/responses/list.json
+++ b/test/Secrets/responses/list.json
@@ -1,0 +1,29 @@
+{
+  "_links": {
+    "self": {
+      "href": "/accounts/abc123/secrets"
+    }
+  },
+  "_embedded": {
+    "secrets": [
+      {
+        "_links": {
+          "self": {
+            "href": "/accounts/abc123/secrets/105abf14-aa00-45a3-9d27-dd19c5920f2c"
+          }
+        },
+        "id": "105abf14-aa00-45a3-9d27-dd19c5920f2c",
+        "created_at": "2020-09-08T21:54:14Z"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "/accounts/abc123/secrets/ed70ae6a-947c-4a65-b95f-7d8ee0844fde"
+          }
+        },
+        "id": "ed70ae6a-947c-4a65-b95f-7d8ee0844fde",
+        "created_at": "2020-06-16T12:58:54Z"
+      }
+    ]
+  }
+}

--- a/test/Secrets/responses/new.json
+++ b/test/Secrets/responses/new.json
@@ -1,0 +1,9 @@
+{
+  "_links": {
+    "self": {
+      "href": "/accounts/abc123/secrets/527ffe03-dfba-46c4-9b40-da5cbefb22c4"
+    }
+  },
+  "id": "527ffe03-dfba-46c4-9b40-da5cbefb22c4",
+  "created_at": "2020-09-08T21:54:14Z"
+}

--- a/test/Secrets/responses/single.json
+++ b/test/Secrets/responses/single.json
@@ -1,0 +1,9 @@
+{
+  "_links": {
+    "self": {
+      "href": "/accounts/abc123/secrets/105abf14-aa00-45a3-9d27-dd19c5920f2c"
+    }
+  },
+  "id": "105abf14-aa00-45a3-9d27-dd19c5920f2c",
+  "created_at": "2020-09-08T21:54:14Z"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This moves all of the logic for Secrets management to it's own client and namespace, and deprecates all the old code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As part of a general move for v3.x and it's breaking changes, the Account client is pulling a lot of weight, as it is doing Secret Management, Pricing, and Account configuration (but not owned Numbers management, which is also under the Account API). While Secrets management resides under the Account API umbrella, it's an API that can live on it's own. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and test scripts.

## Example Output or Screenshots (if appropriate):
Accessing the client can be done with:

```php
$client->secrets()->[method]();
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
