### PR TITLE
Wraps User and Conversation clients in a factory

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -39,7 +39,7 @@ use Vonage\Client\Exception\Exception as ClientException;
 use Vonage\Client\Factory\FactoryInterface;
 use Vonage\Client\Factory\MapFactory;
 use Vonage\Client\Signature;
-use Vonage\Conversations\Collection as ConversationsCollection;
+use Vonage\Conversations\ClientFactory as ConversationsClientFactory;
 use Vonage\Conversion\ClientFactory as ConversionClientFactory;
 use Vonage\Entity\EntityInterface;
 use Vonage\Insights\ClientFactory as InsightsClientFactory;
@@ -48,7 +48,6 @@ use Vonage\Message\Client as MessageClient;
 use Vonage\Numbers\ClientFactory as NumbersClientFactory;
 use Vonage\Redact\ClientFactory as RedactClientFactory;
 use Vonage\SMS\ClientFactory as SMSClientFactory;
-use Vonage\User\Collection as UserCollection;
 use Vonage\Verify\ClientFactory as VerifyClientFactory;
 use Vonage\Verify\Verification;
 use Vonage\Voice\ClientFactory as VoiceClientFactory;
@@ -57,7 +56,6 @@ use function array_key_exists;
 use function array_merge;
 use function base64_encode;
 use function call_user_func_array;
-use function class_exists;
 use function get_class;
 use function http_build_query;
 use function implode;
@@ -72,6 +70,7 @@ use function str_replace;
 use function strpos;
 use function unserialize;
 use Vonage\Logger\LoggerTrait;
+use Vonage\User\ClientFactory as UserClientFactory;
 
 /**
  * Vonage API Client, allows access to the API from PHP.
@@ -86,6 +85,8 @@ use Vonage\Logger\LoggerTrait;
  * @method SMS\Client sms()
  * @method Verify\Client  verify()
  * @method Voice\Client voice()
+ * @method User\Collection user()
+ * @method Conversation\Collection conversation()
  *
  * @property string restUrl
  * @property string apiUrl
@@ -202,8 +203,8 @@ class Client implements LoggerAwareInterface
                     // Legacy Namespaces
                     'message' => MessageClient::class,
                     'calls' => Collection::class,
-                    'conversation' => ConversationsCollection::class,
-                    'user' => UserCollection::class,
+                    'conversation' => ConversationsClientFactory::class,
+                    'user' => UserClientFactory::class,
 
                     // Registered Services by name
                     'account' => ClientFactory::class,

--- a/src/Conversations/ClientFactory.php
+++ b/src/Conversations/ClientFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Vonage\Conversations;
+
+use Vonage\Client\Factory\MapFactory;
+
+class ClientFactory
+{
+    public function __invoke(MapFactory $factory)
+    {
+        $collection = new Collection();
+        $collection->setClient($factory->getClient());
+
+        return $collection;
+    }
+}

--- a/src/User/ClientFactory.php
+++ b/src/User/ClientFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Vonage\User;
+
+use Vonage\Client\Factory\MapFactory;
+
+class ClientFactory
+{
+    public function __invoke(MapFactory $factory)
+    {
+        $collection = new Collection();
+        $collection->setClient($factory->getClient());
+
+        return $collection;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds two small factories to wrap the Conversations and Users collection objects

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A while back we made a change to the MapFactory that allows it to understand the idea of invokable objects as factories, and to expect invokables to be factories. The Conversation and User entry points are invokable but not factories, so this causes an issue if you try and use those APIs. While they are deprecated, this allows them to be used if needed as deprecation does not mean something should be broken.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test scripts

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
