### PR TITLE
Moved authentication logic to individual handlers

### DIFF
--- a/src/Client/Credentials/Handler/AbstractHandler.php
+++ b/src/Client/Credentials/Handler/AbstractHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\Container;
+use Vonage\Client\Credentials\CredentialsInterface;
+
+abstract class AbstractHandler
+{
+    abstract function __invoke(RequestInterface $request, CredentialsInterface $credentials);
+
+    protected function extract(string $class, CredentialsInterface $credentials): CredentialsInterface
+    {
+        if ($credentials instanceof $class) {
+            return $credentials;
+        }
+
+        if ($credentials instanceof Container) {
+            $creds = $credentials->get($class);
+            if (!is_null($creds)) {
+                return $creds;
+            }
+        }
+
+        throw new \RuntimeException('Requested auth type not found');
+    }
+}

--- a/src/Client/Credentials/Handler/BasicHandler.php
+++ b/src/Client/Credentials/Handler/BasicHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\Basic;
+use Vonage\Client\Credentials\CredentialsInterface;
+
+class BasicHandler extends AbstractHandler
+{
+    public function __invoke(RequestInterface $request, CredentialsInterface $credentials)
+    {
+        $credentials = $this->extract(Basic::class, $credentials);
+
+        $c = $credentials->asArray();
+        $cx = base64_encode($c['api_key'] . ':' . $c['api_secret']);
+
+        $request = $request->withHeader('Authorization', 'Basic ' . $cx);
+
+        return $request;
+    }
+}

--- a/src/Client/Credentials/Handler/HandlerInterface.php
+++ b/src/Client/Credentials/Handler/HandlerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\CredentialsInterface;
+
+interface HandlerInterface
+{
+    /**
+     * Add authentication to a request
+     */
+    function __invoke(RequestInterface $request, CredentialsInterface $credentials): RequestInterface;
+}

--- a/src/Client/Credentials/Handler/KeypairHandler.php
+++ b/src/Client/Credentials/Handler/KeypairHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\CredentialsInterface;
+use Vonage\Client\Credentials\Keypair;
+
+class KeypairHandler extends AbstractHandler
+{
+    public function __invoke(RequestInterface $request, CredentialsInterface $credentials)
+    {
+        /** @var Keypair $credentials  */
+        $credentials = $this->extract(Keypair::class, $credentials);
+        $token = $credentials->generateJwt();
+
+        return $request->withHeader('Authorization', 'Bearer ' . $token->toString());
+    }
+}

--- a/src/Client/Credentials/Handler/SignatureBodyFormHandler.php
+++ b/src/Client/Credentials/Handler/SignatureBodyFormHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\CredentialsInterface;
+use Vonage\Client\Credentials\SignatureSecret;
+use Vonage\Client\Signature;
+
+class SignatureBodyFormHandler extends AbstractHandler
+{
+    public function __invoke(RequestInterface $request, CredentialsInterface $credentials)
+    {
+        $credentials = $this->extract(SignatureSecret::class, $credentials);
+
+        $body = $request->getBody();
+        $body->rewind();
+        $content = $body->getContents();
+        $params = [];
+        parse_str($content, $params);
+        $params['api_key'] = $credentials['api_key'];
+        $signature = new Signature($params, $credentials['signature_secret'], $credentials['signature_method']);
+        $params = $signature->getSignedParams();
+        $body->rewind();
+        $body->write(http_build_query($params, '', '&'));
+
+        return $request;
+    }
+}

--- a/src/Client/Credentials/Handler/SignatureBodyHandler.php
+++ b/src/Client/Credentials/Handler/SignatureBodyHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\CredentialsInterface;
+use Vonage\Client\Credentials\SignatureSecret;
+use Vonage\Client\Signature;
+
+class SignatureBodyHandler extends AbstractHandler
+{
+    public function __invoke(RequestInterface $request, CredentialsInterface $credentials)
+    {
+        $credentials = $this->extract(SignatureSecret::class, $credentials);
+
+        $body = $request->getBody();
+        $body->rewind();
+        $content = $body->getContents();
+        $params = json_decode($content, true);
+        $params['api_key'] = $credentials['api_key'];
+        $signature = new Signature($params, $credentials['signature_secret'], $credentials['signature_method']);
+        $body->rewind();
+        $body->write(json_encode($signature->getSignedParams()));
+
+        return $request;
+    }
+}

--- a/src/Client/Credentials/Handler/SignatureQueryHandler.php
+++ b/src/Client/Credentials/Handler/SignatureQueryHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\CredentialsInterface;
+use Vonage\Client\Credentials\SignatureSecret;
+use Vonage\Client\Signature;
+
+class SignatureQueryHandler extends AbstractHandler
+{
+    public function __invoke(RequestInterface $request, CredentialsInterface $credentials)
+    {
+        $credentials = $this->extract(SignatureSecret::class, $credentials);
+
+        $query = [];
+        parse_str($request->getUri()->getQuery(), $query);
+        $query['api_key'] = $credentials['api_key'];
+        $signature = new Signature($query, $credentials['signature_secret'], $credentials['signature_method']);
+        $request = $request->withUri(
+            $request->getUri()->withQuery(http_build_query($signature->getSignedParams()))
+        );
+
+        return $request;
+    }
+}

--- a/src/Client/Credentials/Handler/TokenBodyFormHandler.php
+++ b/src/Client/Credentials/Handler/TokenBodyFormHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Vonage\Client\Credentials\Basic;
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\CredentialsInterface;
+
+class TokenBodyFormHandler extends AbstractHandler
+{
+    public function __invoke(RequestInterface $request, CredentialsInterface $credentials)
+    {
+        $credentials = $this->extract(Basic::class, $credentials);
+        $body = $request->getBody();
+        $body->rewind();
+        $content = $body->getContents();
+        $params = [];
+        parse_str($content, $params);
+        $params = array_merge($params, $credentials->asArray());
+        $body->rewind();
+        $body->write(http_build_query($params, '', '&'));
+
+        return $request;
+    }
+}

--- a/src/Client/Credentials/Handler/TokenBodyHandler.php
+++ b/src/Client/Credentials/Handler/TokenBodyHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Vonage\Client\Credentials\Basic;
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\CredentialsInterface;
+
+class TokenBodyHandler extends AbstractHandler
+{
+    public function __invoke(RequestInterface $request, CredentialsInterface $credentials)
+    {
+        $credentials = $this->extract(Basic::class, $credentials);
+        $body = $request->getBody();
+        $body->rewind();
+        $content = $body->getContents();
+        $params = json_decode($content, true);
+
+        if (!$params) {
+            $params = [];
+        }
+
+        $params = array_merge($params, $credentials->asArray());
+        $body->rewind();
+        $body->write(json_encode($params));
+
+        return $request;
+    }
+}

--- a/src/Client/Credentials/Handler/TokenQueryHandler.php
+++ b/src/Client/Credentials/Handler/TokenQueryHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Vonage\Client\Credentials\Basic;
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\CredentialsInterface;
+
+class TokenQueryHandler extends AbstractHandler
+{
+    public function __invoke(RequestInterface $request, CredentialsInterface $credentials)
+    {
+        $credentials = $this->extract(Basic::class, $credentials);
+        $query = [];
+        parse_str($request->getUri()->getQuery(), $query);
+        $query = array_merge($query, $credentials->asArray());
+
+        $request = $request->withUri($request->getUri()->withQuery(http_build_query($query)));
+
+        return $request;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently all authentication logic is handled by `Vonage\Client` and spread out in various methods. This change moves each authentication type we support to a handler, and changes the Client to use these handlers. This also adds the abilities for `Vonage\Client\APIResource` to eventually handle it's own authentication, but this is not directly implemented (it would cause most of the auth types to apply twice). 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As #280 explains, we currently do not have the ability to support both basic authentication and signature authentication when a user wants to use two APIs and one only supports basic, but the other supports Signature (for example, Account and SMS). This is largely due to some bad assumptions when deciding which authentication to use. Ultimately `Vonage\Client` should not be making this determination and it should be left to the individual `APIResource` objects. This PR moves auth to something that can be used anywhere, and preps `APIResource` for the future, specifically v3.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and against the code snippets locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
