### PR TITLE
Properly handle MT Throttling and SMS Throttle Time

### DIFF
--- a/src/Message/Client.php
+++ b/src/Message/Client.php
@@ -108,7 +108,7 @@ class Client implements ClientAwareInterface
                                 $e->setTimeout(1);
                                 $e->setEntity($data);
 
-                                if (preg_match('#\[\s+(\d+)\s+]#', $part['error-text'], $match)) {
+                                if (preg_match('#Throughput Rate Exceeded - please wait \[\s+(\d+)\s+] and retry#', $part['error-text'], $match)) {
                                     $seconds = max((int)$match[1] / 1000, 1);
                                     $e->setTimeout($seconds);
                                 }

--- a/src/Message/Client.php
+++ b/src/Message/Client.php
@@ -109,7 +109,8 @@ class Client implements ClientAwareInterface
                                 $e->setEntity($data);
 
                                 if (preg_match('#\[\s+(\d+)\s+]#', $part['error-text'], $match)) {
-                                    $e->setTimeout((int)$match[1] + 1);
+                                    $seconds = max((int)$match[1] / 1000, 1);
+                                    $e->setTimeout($seconds);
                                 }
 
                                 throw $e;

--- a/src/SMS/ExceptionErrorHandler.php
+++ b/src/SMS/ExceptionErrorHandler.php
@@ -56,7 +56,7 @@ class ExceptionErrorHandler
                     $e->setTimeout(1);
                     $e->setEntity($data);
 
-                    if (preg_match('#\[\s+(\d+)\s+]#', $part['error-text'], $match)) {
+                    if (preg_match('#Throughput Rate Exceeded - please wait \[\s+(\d+)\s+] and retry#', $part['error-text'], $match)) {
                         $seconds = max((int)$match[1] / 1000, 1);
                         $e->setTimeout($seconds);
                     }

--- a/src/SMS/ExceptionErrorHandler.php
+++ b/src/SMS/ExceptionErrorHandler.php
@@ -57,7 +57,8 @@ class ExceptionErrorHandler
                     $e->setEntity($data);
 
                     if (preg_match('#\[\s+(\d+)\s+]#', $part['error-text'], $match)) {
-                        $e->setTimeout((int)$match[1] + 1);
+                        $seconds = max((int)$match[1] / 1000, 1);
+                        $e->setTimeout($seconds);
                     }
 
                     throw $e;

--- a/test/Message/ClientTest.php
+++ b/test/Message/ClientTest.php
@@ -673,6 +673,7 @@ class ClientTest extends TestCase
      */
     public function testRateLimitRetries(): void
     {
+        $start = microtime(true);
         $rate = $this->getResponse('ratelimit');
         $rate2 = $this->getResponse('ratelimit');
         $success = $this->getResponse('success');
@@ -692,8 +693,10 @@ class ClientTest extends TestCase
         }))->willReturn($rate, $rate2, $success);
 
         $message = $this->messageClient->send(new Text($args['to'], $args['from'], $args['text']));
+        $end = microtime(true);
 
         $this->assertEquals($success, @$message->getResponse());
+        $this->assertGreaterThanOrEqual(2, $end - $start);
     }
 
     /**

--- a/test/Message/responses/mt-limit.json
+++ b/test/Message/responses/mt-limit.json
@@ -1,0 +1,9 @@
+{
+  "message-count": "1",
+  "messages": [
+    {
+      "status": "1",
+      "error-text": "Exceeded maximum MT throughput[ MAX [ 30 ] INTERVAL [ 1000 ] COUNT [ 30 ] LAST INT-START [ 1617784922564 ] TIME_SINCE_LAST_INTERVAL_START [ 529 ]  ] "
+    }
+  ]
+}

--- a/test/SMS/ClientTest.php
+++ b/test/SMS/ClientTest.php
@@ -154,6 +154,7 @@ class ClientTest extends TestCase
      */
     public function testCanHandleRateLimitRequests(): void
     {
+        $start = microtime(true);
         $rate = $this->getResponse('ratelimit');
         $rate2 = $this->getResponse('ratelimit');
         $success = $this->getResponse('send-success');
@@ -173,6 +174,7 @@ class ClientTest extends TestCase
 
         $response = $this->smsClient->send(new SMS($args['to'], $args['from'], $args['text']));
         $sentData = $response->current();
+        $end = microtime(true);
 
         $this->assertCount(1, $response);
         $this->assertSame($args['to'], $sentData->getTo());
@@ -181,6 +183,7 @@ class ClientTest extends TestCase
         $this->assertSame("12345", $sentData->getNetwork());
         $this->assertSame("3.14159265", $sentData->getRemainingBalance());
         $this->assertSame(0, $sentData->getStatus());
+        $this->assertGreaterThanOrEqual(2, $end - $start);
     }
 
     /**

--- a/test/SMS/ClientTest.php
+++ b/test/SMS/ClientTest.php
@@ -226,6 +226,44 @@ class ClientTest extends TestCase
      * @throws ClientExceptionInterface
      * @throws Client\Exception\Exception
      */
+    public function testCanHandleAPIRateLimitRequests(): void
+    {
+        $start = microtime(true);
+        $rate = $this->getResponse('mt-limit');
+        $rate2 = $this->getResponse('mt-limit');
+        $success = $this->getResponse('send-success');
+        $args = [
+            'to' => '447700900000',
+            'from' => '1105551334',
+            'text' => 'test message'
+        ];
+
+        $this->vonageClient->send(Argument::that(function (Request $request) use ($args) {
+            $this->assertRequestJsonBodyContains('to', $args['to'], $request);
+            $this->assertRequestJsonBodyContains('from', $args['from'], $request);
+            $this->assertRequestJsonBodyContains('text', $args['text'], $request);
+
+            return true;
+        }))->willReturn($rate, $rate2, $success);
+
+        $response = $this->smsClient->send(new SMS($args['to'], $args['from'], $args['text']));
+        $sentData = $response->current();
+        $end = microtime(true);
+
+        $this->assertCount(1, $response);
+        $this->assertSame($args['to'], $sentData->getTo());
+        $this->assertSame('0A0000000123ABCD1', $sentData->getMessageId());
+        $this->assertSame("0.03330000", $sentData->getMessagePrice());
+        $this->assertSame("12345", $sentData->getNetwork());
+        $this->assertSame("3.14159265", $sentData->getRemainingBalance());
+        $this->assertSame(0, $sentData->getStatus());
+        $this->assertGreaterThanOrEqual(2, $end - $start);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws Client\Exception\Exception
+     */
     public function testCanUnderstandMultiMessageResponses(): void
     {
         $args = [

--- a/test/SMS/responses/mt-limit.json
+++ b/test/SMS/responses/mt-limit.json
@@ -1,0 +1,9 @@
+{
+  "message-count": "1",
+  "messages": [
+    {
+      "status": "1",
+      "error-text": "Exceeded maximum MT throughput[ MAX [ 30 ] INTERVAL [ 1000 ] COUNT [ 30 ] LAST INT-START [ 1617784922564 ] TIME_SINCE_LAST_INTERVAL_START [ 529 ]  ] "
+    }
+  ]
+}

--- a/test/SMS/responses/ratelimit.json
+++ b/test/SMS/responses/ratelimit.json
@@ -4,7 +4,7 @@
     {
       "to": "14843472194",
       "status": "1",
-      "error-text": "Throughput Rate Exceeded - please wait [ 2 ] and retry",
+      "error-text": "Throughput Rate Exceeded - please wait [ 702 ] and retry",
       "network": "310260"
     }
   ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #282 

This switches the exception handlers to deal with the proposed throttle time in milliseconds, with a minimum of 1 second. The code originally took the proposed value as seconds and increased it by that plus 1, leading to very long throttling times.

This fix also tightens the regex for determining throttle times so it only handles SMS throttles. Generic API message terminating limits now throttle for 1 second, since API throttles are based on messages per second.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The SMS throttle messages can return very high proposed values as they are in milliseconds, not seconds. This leads to scripts timing out as values like "702" were interpreted as 702 seconds, not .702 seconds. We use a minimum of 1 as `sleep()` assumes seconds, and it's better to be slightly longer than too short and trigger another throttle.

The Regex fix stops the problem reported in #282 were we incorrectly grabbed a value because of a very loose regex.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
