### PR TITLE
Explicitly set the sub if required

### DIFF
--- a/src/Client/Credentials/Keypair.php
+++ b/src/Client/Credentials/Keypair.php
@@ -88,6 +88,12 @@ class Keypair extends AbstractCredentials
             $builder->withClaim('application_id', $this->credentials['application']);
         }
 
+        if (isset($claims['sub'])) {
+            $builder->relatedTo($claims['sub']);
+
+            unset($claims['sub']);
+        }
+
         if (!empty($claims)) {
             foreach ($claims as $claim => $value) {
                 $builder->withClaim($claim, $value);

--- a/test/Client/Credentials/KeypairTest.php
+++ b/test/Client/Credentials/KeypairTest.php
@@ -93,6 +93,39 @@ class KeypairTest extends TestCase
     }
 
     /**
+     * @link https://github.com/Vonage/vonage-php-sdk-core/issues/276
+     */
+    public function testExampleConversationJWTWorks()
+    {
+        $credentials = new Keypair($this->key, $this->application);
+        $claims = [
+            'exp' => strtotime(date('Y-m-d', strtotime('+24 Hours'))),
+            'sub' => 'apg-cs',
+            'acl' => [
+                'paths' => [
+                    '/*/users/**' => (object) [],
+                    '/*/conversations/**' => (object) [],
+                    '/*/sessions/**' => (object) [],
+                    '/*/devices/**' => (object) [],
+                    '/*/image/**' => (object) [],
+                    '/*/media/**' => (object) [],
+                    '/*/applications/**' => (object) [],
+                    '/*/push/**' => (object) [],
+                    '/*/knocking/**' => (object) [],
+                    '/*/legs/**' => (object) [],
+                ]
+            ],
+        ];
+
+        $jwt = $credentials->generateJwt($claims);
+        [, $payload] = $this->decodeJWT($jwt->toString());
+
+        $this->assertArrayHasKey('exp', $payload);
+        $this->assertEquals($claims['exp'], $payload['exp']);
+        $this->assertEquals($claims['sub'], $payload['sub']);
+    }
+
+    /**
      * @param $jwt
      */
     protected function decodeJWT($jwt): array


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To work around a change in the JWT dependency we have, explicitly check for and set the `sub` parameter.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In newer versions of `lcobucci/jwt` the `sub` header can no longer be set as an arbitrary claim. Unfortunately to keep the wide berth of PHP versions we use we have to keep 3.x compatibility and 4.x compatibility, so this fix helps bridge that gap some more.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and local test scripts

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
