### PR TITLE
Fix prophecy to use trait, update maintainer details

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0' ]
+        php: [ '7.4', '8.0' ]
     name: PHP ${{ matrix.php }} Test
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.4', '8.0' ]
+        php: [ '7.4', '8.0', '8.1' ]
     name: PHP ${{ matrix.php }} Test
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.10.0
+
+### Fixed
+
+* PHPUnit tests now no longer throw `prophesize()` depreciation notices
+
+### Changed
+
+* Maintainer and Contribution documents changed to reflect current ownership
+* All test cases now extend off a the new `VonageTestCase` class that implements the `ProphesizeTrait`
+
 # 2.9.3
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,13 +1,14 @@
 ## Maintainers
 
 If you have any problems with our library, feel free to reach out to our
-maintainers.
+maintainer.
 
-* [Chris Tankersley](https://github.com/dragonmantank)
-* [Lorna Jane Mitchell](https://github.com/lornajane)
+* [James Seconde](https://github.com/secondejk)
 
 ### Past Maintainers
 
+* [Chris Tankersley](https://github.com/dragonmantank)
+* [Lorna Jane Mitchell](https://github.com/lornajane)
 * [Tim Lytle](https://github.com/tjlytle)
 * [Micheal Heap](https://github.com/mheap)
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4",
+    "php": ">=7.2",
     "ext-json": "*",
     "ext-mbstring": "*",
     "laminas/laminas-diactoros": "^2.4",
@@ -24,6 +24,7 @@
     "psr/log": "^1.1"
   },
   "require-dev": {
+    "php": ">=7.4",
     "guzzlehttp/guzzle": ">=6",
     "helmich/phpunit-json-assert": "^3.3",
     "php-http/mock-client": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,9 @@
   "license": "Apache-2.0",
   "authors": [
     {
-      "name": "Chris Tankersley",
-      "email": "chris.tankersley@vonage.com",
-      "role": "Developer"
-    },
-    {
-      "name": "Lorna Mitchell",
-      "email": "lorna.mitchell@vonage.com",
-      "role": "Developer"
+      "name": "James Seconde",
+      "email": "jim.seconde@vonage.com",
+      "role": "PHP Developer Advocate"
     }
   ],
   "require": {
@@ -36,7 +31,8 @@
     "phpunit/phpunit": "^8.5|^9.4",
     "roave/security-advisories": "dev-latest",
     "squizlabs/php_codesniffer": "^3.5",
-    "softcreatr/jsonpath": "^0.6.4"
+    "softcreatr/jsonpath": "^0.6.4",
+    "phpspec/prophecy-phpunit": "^2.0"
   },
   "config": {
     "optimize-autoloader": true,
@@ -62,6 +58,6 @@
     "email": "devrel@vonage.com",
     "issues": "https://github.com/Vonage/vonage-php-sdk-core/issues",
     "source": "https://github.com/Vonage/vonage-php-sdk-core",
-    "docs": "https://developer.nexmo.com"
+    "docs": "https://developer.vonage.com"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "ext-json": "*",
     "ext-mbstring": "*",
     "laminas/laminas-diactoros": "^2.4",

--- a/test/Account/BalanceTest.php
+++ b/test/Account/BalanceTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace VonageTest\Account;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Account\Balance;
 use Vonage\Client\Exception\Exception as ClientException;
 
-class BalanceTest extends TestCase
+class BalanceTest extends VonageTestCase
 {
     /**
      * @var Balance

--- a/test/Account/ClientFactoryTest.php
+++ b/test/Account/ClientFactoryTest.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace VonageTest\Account;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Account\ClientFactory;
 use Vonage\Client;
 use Vonage\Client\APIResource;
 use Vonage\Client\Factory\MapFactory;
 
-class ClientFactoryTest extends TestCase
+class ClientFactoryTest extends VonageTestCase
 {
     /**
      * @var MapFactory

--- a/test/Account/ClientTest.php
+++ b/test/Account/ClientTest.php
@@ -12,8 +12,9 @@ declare(strict_types=1);
 namespace VonageTest\Account;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Vonage\Account\Client as AccountClient;
@@ -29,9 +30,10 @@ use VonageTest\Psr7AssertionTrait;
 
 use function fopen;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
+
 
     protected $vonageClient;
 

--- a/test/Account/ConfigTest.php
+++ b/test/Account/ConfigTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Account;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Account\Config;
 
-class ConfigTest extends TestCase
+class ConfigTest extends VonageTestCase
 {
     /**
      * @var Config

--- a/test/Account/PrefixPriceTest.php
+++ b/test/Account/PrefixPriceTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace VonageTest\Account;
 
 use Exception;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Account\PrefixPrice;
 
-class PrefixPriceTest extends TestCase
+class PrefixPriceTest extends VonageTestCase
 {
     /**
      * @dataProvider prefixPriceProvider

--- a/test/Account/SecretCollectionTest.php
+++ b/test/Account/SecretCollectionTest.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
 
 namespace VonageTest\Account;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Account\Secret;
 use Vonage\Account\SecretCollection;
 use Vonage\InvalidResponseException;
 
 use function array_map;
 
-class SecretCollectionTest extends TestCase
+class SecretCollectionTest extends VonageTestCase
 {
     /**
      * @var array[]

--- a/test/Account/SecretTest.php
+++ b/test/Account/SecretTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace VonageTest\Account;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Account\Secret;
 use Vonage\InvalidResponseException;
 
-class SecretTest extends TestCase
+class SecretTest extends VonageTestCase
 {
     /**
      * @var Secret

--- a/test/Account/SmsPriceTest.php
+++ b/test/Account/SmsPriceTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Account;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Account\SmsPrice;
 
-class SmsPriceTest extends TestCase
+class SmsPriceTest extends VonageTestCase
 {
     /**
      * @dataProvider smsPriceProvider

--- a/test/ApiErrorHandlerTest.php
+++ b/test/ApiErrorHandlerTest.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
 namespace VonageTest;
 
 use Exception;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\ApiErrorHandler;
 use Vonage\Client\Exception\Request as RequestException;
 use Vonage\Client\Exception\Server as ServerException;
 use Vonage\Client\Exception\Validation as ValidationException;
 
-class ApiErrorHandlerTest extends TestCase
+class ApiErrorHandlerTest extends VonageTestCase
 {
     /**
      * Valid HTTP responses do not throw an error

--- a/test/Application/ApplicationTest.php
+++ b/test/Application/ApplicationTest.php
@@ -13,7 +13,7 @@ namespace VonageTest\Application;
 
 use Exception;
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Application\Application;
 use Vonage\Application\MessagesConfig;
 use Vonage\Application\RtcConfig;
@@ -22,7 +22,7 @@ use Vonage\Client\Exception\Exception as ClientException;
 
 use function fopen;
 
-class ApplicationTest extends TestCase
+class ApplicationTest extends VonageTestCase
 {
     /**
      * @var Application

--- a/test/Application/ClientTest.php
+++ b/test/Application/ClientTest.php
@@ -15,7 +15,7 @@ use DateTime;
 use Exception;
 use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -37,7 +37,7 @@ use function is_null;
 use function json_decode;
 use function substr;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Application/FilterTest.php
+++ b/test/Application/FilterTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace VonageTest\Application;
 
 use DateTime;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Application\Filter;
 
-class FilterTest extends TestCase
+class FilterTest extends VonageTestCase
 {
     /**
      * @dataProvider ranges

--- a/test/Call/CallTest.php
+++ b/test/Call/CallTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -34,7 +34,7 @@ use function fopen;
 use function json_decode;
 use function json_encode;
 
-class CallTest extends TestCase
+class CallTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Call/CollectionTest.php
+++ b/test/Call/CollectionTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -27,7 +27,7 @@ use VonageTest\Psr7AssertionTrait;
 use function fopen;
 use function json_encode;
 
-class CollectionTest extends TestCase
+class CollectionTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Call/DtmfTest.php
+++ b/test/Call/DtmfTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -25,7 +25,7 @@ use function fopen;
 use function json_decode;
 use function json_encode;
 
-class DtmfTest extends TestCase
+class DtmfTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Call/EarmuffTest.php
+++ b/test/Call/EarmuffTest.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Helmich\JsonAssert\JsonAssertions;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Call\Earmuff;
 
 use function file_get_contents;
 use function json_decode;
 use function json_encode;
 
-class EarmuffTest extends TestCase
+class EarmuffTest extends VonageTestCase
 {
     use JsonAssertions;
 

--- a/test/Call/EventTest.php
+++ b/test/Call/EventTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace VonageTest\Call;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Call\Event;
 use VonageTest\Fixture\ResponseTrait;
 
-class EventTest extends TestCase
+class EventTest extends VonageTestCase
 {
     use ResponseTrait;
 

--- a/test/Call/FilterTest.php
+++ b/test/Call/FilterTest.php
@@ -12,11 +12,11 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use DateTime;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Call\Filter;
 use Vonage\Conversations\Conversation;
 
-class FilterTest extends TestCase
+class FilterTest extends VonageTestCase
 {
     /**
      * @var Filter

--- a/test/Call/HangupTest.php
+++ b/test/Call/HangupTest.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Helmich\JsonAssert\JsonAssertions;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Call\Hangup;
 
 use function file_get_contents;
 use function json_decode;
 use function json_encode;
 
-class HangupTest extends TestCase
+class HangupTest extends VonageTestCase
 {
     use JsonAssertions;
 

--- a/test/Call/MuteTest.php
+++ b/test/Call/MuteTest.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Helmich\JsonAssert\JsonAssertions;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Call\Mute;
 
 use function file_get_contents;
 use function json_decode;
 use function json_encode;
 
-class MuteTest extends TestCase
+class MuteTest extends VonageTestCase
 {
     use JsonAssertions;
 

--- a/test/Call/StreamTest.php
+++ b/test/Call/StreamTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -25,7 +25,7 @@ use function fopen;
 use function json_decode;
 use function json_encode;
 
-class StreamTest extends TestCase
+class StreamTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Call/TalkTest.php
+++ b/test/Call/TalkTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -27,7 +27,7 @@ use function fopen;
 use function json_decode;
 use function json_encode;
 
-class TalkTest extends TestCase
+class TalkTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Call/TransferTest.php
+++ b/test/Call/TransferTest.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Helmich\JsonAssert\JsonAssertions;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Call\Transfer;
 
 use function file_get_contents;
 use function json_decode;
 use function json_encode;
 
-class TransferTest extends TestCase
+class TransferTest extends VonageTestCase
 {
     use JsonAssertions;
 

--- a/test/Call/UnearmuffTest.php
+++ b/test/Call/UnearmuffTest.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Helmich\JsonAssert\JsonAssertions;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Call\Unearmuff;
 
 use function file_get_contents;
 use function json_decode;
 use function json_encode;
 
-class UnearmuffTest extends TestCase
+class UnearmuffTest extends VonageTestCase
 {
     use JsonAssertions;
 

--- a/test/Call/UnmuteTest.php
+++ b/test/Call/UnmuteTest.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
 namespace VonageTest\Call;
 
 use Helmich\JsonAssert\JsonAssertions;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Call\Unmute;
 
 use function file_get_contents;
 use function json_decode;
 use function json_encode;
 
-class UnmuteTest extends TestCase
+class UnmuteTest extends VonageTestCase
 {
     use JsonAssertions;
 

--- a/test/Client/APIResourceTest.php
+++ b/test/Client/APIResourceTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace VonageTest\Client;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client;
 use Vonage\Client\APIResource;
 
-class APIResourceTest extends TestCase
+class APIResourceTest extends VonageTestCase
 {
     public function testOverridingBaseUrlUsesClientApiUrl(): void
     {

--- a/test/Client/Credentials/BasicTest.php
+++ b/test/Client/Credentials/BasicTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Client\Credentials;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client\Credentials\Basic;
 
-class BasicTest extends TestCase
+class BasicTest extends VonageTestCase
 {
     protected $key = 'key';
     protected $secret = 'secret';

--- a/test/Client/Credentials/ContainerTest.php
+++ b/test/Client/Credentials/ContainerTest.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace VonageTest\Client\Credentials;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client\Credentials\Basic;
 use Vonage\Client\Credentials\Container;
 use Vonage\Client\Credentials\Keypair;
 use Vonage\Client\Credentials\SignatureSecret;
 
-class ContainerTest extends TestCase
+class ContainerTest extends VonageTestCase
 {
     protected $types = [
         Basic::class,

--- a/test/Client/Credentials/KeypairTest.php
+++ b/test/Client/Credentials/KeypairTest.php
@@ -9,7 +9,7 @@
 
 namespace VonageTest\Client\Credentials;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client\Credentials\Keypair;
 
 use function base64_decode;
@@ -17,7 +17,7 @@ use function explode;
 use function file_get_contents;
 use function json_decode;
 
-class KeypairTest extends TestCase
+class KeypairTest extends VonageTestCase
 {
     protected $key;
     protected $application = 'c90ddd99-9a5d-455f-8ade-dde4859e590e';

--- a/test/Client/Credentials/OAuthTest.php
+++ b/test/Client/Credentials/OAuthTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Client\Credentials;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client\Credentials\OAuth;
 
-class OAuthTest extends TestCase
+class OAuthTest extends VonageTestCase
 {
     protected $appToken = 'appToken';
     protected $appSecret = 'appSecret';

--- a/test/Client/Factory/MapFactoryTest.php
+++ b/test/Client/Factory/MapFactoryTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace VonageTest\Client\Factory;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use RuntimeException;
 use Vonage\Client;
 use Vonage\Client\Factory\MapFactory;
 
-class MapFactoryTest extends TestCase
+class MapFactoryTest extends VonageTestCase
 {
     /**
      * @var MapFactory

--- a/test/Client/SignatureTest.php
+++ b/test/Client/SignatureTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace VonageTest\Client;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client\Exception\Exception as ClientException;
 use Vonage\Client\Signature;
 
-class SignatureTest extends TestCase
+class SignatureTest extends VonageTestCase
 {
     public function testInvalidSignatureMethod(): void
     {

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -17,7 +17,7 @@ use Http\Mock\Client as HttpMock;
 use InvalidArgumentException;
 use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -36,7 +36,7 @@ use function parse_str;
 use function serialize;
 use function set_include_path;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Conversation/CollectionTest.php
+++ b/test/Conversation/CollectionTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\Conversation;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -25,7 +25,7 @@ use VonageTest\Psr7AssertionTrait;
 use function fopen;
 use function json_encode;
 
-class CollectionTest extends TestCase
+class CollectionTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Conversion/ClientTest.php
+++ b/test/Conversion/ClientTest.php
@@ -13,7 +13,7 @@ namespace VonageTest\Conversion;
 
 use Laminas\Diactoros\Response;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Vonage\Client;
@@ -26,7 +26,7 @@ use VonageTest\Psr7AssertionTrait;
 
 use function fopen;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Insights/AdvancedTest.php
+++ b/test/Insights/AdvancedTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Insights;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Insights\Advanced;
 
-class AdvancedTest extends TestCase
+class AdvancedTest extends VonageTestCase
 {
     /**
      * @dataProvider advancedTestProvider

--- a/test/Insights/BasicTest.php
+++ b/test/Insights/BasicTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Insights;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Insights\Basic;
 
-class BasicTest extends TestCase
+class BasicTest extends VonageTestCase
 {
     /**
      * @dataProvider basicTestProvider

--- a/test/Insights/ClientTest.php
+++ b/test/Insights/ClientTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\Insights;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -30,7 +30,7 @@ use VonageTest\Psr7AssertionTrait;
 
 use function fopen;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Insights/CnamTraitTest.php
+++ b/test/Insights/CnamTraitTest.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace VonageTest\Insights;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 
-class CnamTraitTest extends TestCase
+class CnamTraitTest extends VonageTestCase
 {
     /**
      * @dataProvider cnamProvider

--- a/test/Insights/StandardTest.php
+++ b/test/Insights/StandardTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Insights;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Insights\Standard;
 
-class StandardTest extends TestCase
+class StandardTest extends VonageTestCase
 {
     /**
      * @dataProvider standardTestProvider

--- a/test/Logger/LoggerTraitTest.php
+++ b/test/Logger/LoggerTraitTest.php
@@ -4,9 +4,9 @@ namespace VonageTest\Logger;
 
 use Psr\Log\LoggerInterface;
 use Vonage\Logger\LoggerTrait;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 
-class LoggerTraitTest extends TestCase
+class LoggerTraitTest extends VonageTestCase
 {
     public function testCanSetAndGetLogger()
     {

--- a/test/Message/AutoDetectTest.php
+++ b/test/Message/AutoDetectTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Message;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Message\AutoDetect;
 
-class AutoDetectTest extends TestCase
+class AutoDetectTest extends VonageTestCase
 {
     /**
      * When creating a message, it should not auto-detect encoding by default

--- a/test/Message/Callback/ReceiptTest.php
+++ b/test/Message/Callback/ReceiptTest.php
@@ -12,12 +12,12 @@ declare(strict_types=1);
 namespace VonageTest\Message\Callback;
 
 use DateTime;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Message\Callback\Receipt;
 
 use function array_merge;
 
-class ReceiptTest extends TestCase
+class ReceiptTest extends VonageTestCase
 {
     protected $data = [
         'err-code' => '0',

--- a/test/Message/ClientTest.php
+++ b/test/Message/ClientTest.php
@@ -16,7 +16,7 @@ use Exception;
 use InvalidArgumentException;
 use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -37,7 +37,7 @@ use VonageTest\Psr7AssertionTrait;
 use function fopen;
 use function json_decode;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
     use MessageAssertionTrait;

--- a/test/Message/EncodingDetectorTest.php
+++ b/test/Message/EncodingDetectorTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Message;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Message\EncodingDetector;
 
-class EncodingDetectorTest extends TestCase
+class EncodingDetectorTest extends VonageTestCase
 {
     /**
      * @dataProvider unicodeProvider

--- a/test/Message/FetchedMessageTest.php
+++ b/test/Message/FetchedMessageTest.php
@@ -14,7 +14,7 @@ namespace VonageTest\Message;
 use DateTime;
 use Exception;
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Message\Message;
 
 use function fopen;
@@ -23,7 +23,7 @@ use function fopen;
  * Test that split messages allow access to all the underlying messages. The response from sending a message is the
  * only time a message may contain multiple 'parts'. When fetched from the API, each message is separate.
  */
-class FetchedMessageTest extends TestCase
+class FetchedMessageTest extends VonageTestCase
 {
     protected $to = '14845551212';
     protected $from = '16105551212';

--- a/test/Message/InboundMessageTest.php
+++ b/test/Message/InboundMessageTest.php
@@ -13,7 +13,7 @@ namespace VonageTest\Message;
 
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequest;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client\Exception\Exception as ClientException;
 use Vonage\Message\InboundMessage;
 use Vonage\Message\Message;
@@ -26,7 +26,7 @@ use function json_decode;
 use function parse_str;
 use function strtoupper;
 
-class InboundMessageTest extends TestCase
+class InboundMessageTest extends VonageTestCase
 {
     public function testConstructionWithId(): void
     {

--- a/test/Message/MessageCreationTest.php
+++ b/test/Message/MessageCreationTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\Message;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client\Exception\Exception as ClientException;
 use Vonage\Message\Message;
 use Vonage\Message\Text;
@@ -21,7 +21,7 @@ use function array_diff;
 use function array_keys;
 use function json_encode;
 
-class MessageCreationTest extends TestCase
+class MessageCreationTest extends VonageTestCase
 {
     protected $to = '14845551212';
     protected $from = '16105551212';

--- a/test/Message/MessageTest.php
+++ b/test/Message/MessageTest.php
@@ -14,7 +14,7 @@ namespace VonageTest\Message;
 use Exception;
 use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client\Exception\Exception as ClientException;
 use Vonage\Message\Message;
 use Vonage\Message\Text;
@@ -23,7 +23,7 @@ use function fopen;
 use function http_build_query;
 use function json_encode;
 
-class MessageTest extends TestCase
+class MessageTest extends VonageTestCase
 {
     protected $to = '14845551212';
     protected $from = '16105551212';

--- a/test/Message/MultiMessageTest.php
+++ b/test/Message/MultiMessageTest.php
@@ -13,7 +13,7 @@ namespace VonageTest\Message;
 
 use Exception;
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Message\Message;
 
 use function fopen;
@@ -22,7 +22,7 @@ use function fopen;
  * Test that split messages allow access to all the underlying messages. The response from sending a message is the
  * only time a message may contain multiple 'parts'. When fetched from the API, each message is separate.
  */
-class MultiMessageTest extends TestCase
+class MultiMessageTest extends VonageTestCase
 {
     protected $to = '14845551212';
     protected $from = '16105551212';

--- a/test/Message/ShortcodeTest.php
+++ b/test/Message/ShortcodeTest.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
 
 namespace VonageTest\Message;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client\Exception\Exception as ClientException;
 use Vonage\Message\Shortcode;
 use Vonage\Message\Shortcode\Alert;
 use Vonage\Message\Shortcode\Marketing;
 use Vonage\Message\Shortcode\TwoFactor;
 
-class ShortcodeTest extends TestCase
+class ShortcodeTest extends VonageTestCase
 {
     /**
      * @dataProvider typeProvider

--- a/test/Network/Number/CallbackTest.php
+++ b/test/Network/Number/CallbackTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace VonageTest\Network\Number;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Network\Number\Callback;
 
 use function array_merge;
 
-class CallbackTest extends TestCase
+class CallbackTest extends VonageTestCase
 {
     protected $data = [
         'request_id' => '12345',

--- a/test/Network/Number/RequestTest.php
+++ b/test/Network/Number/RequestTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace VonageTest\Network\Number;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Network\Number\Request;
 
 use function explode;
 
-class RequestTest extends TestCase
+class RequestTest extends VonageTestCase
 {
     public function testNullValuesNotPresent(): void
     {

--- a/test/Network/Number/ResponseTest.php
+++ b/test/Network/Number/ResponseTest.php
@@ -12,11 +12,11 @@ declare(strict_types=1);
 namespace VonageTest\Network\Number;
 
 use BadMethodCallException;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Network\Number\Callback;
 use Vonage\Network\Number\Response;
 
-class ResponseTest extends TestCase
+class ResponseTest extends VonageTestCase
 {
     protected $data = [
         'request_id' => '12345',

--- a/test/NetworkTest.php
+++ b/test/NetworkTest.php
@@ -9,10 +9,10 @@
 
 namespace VonageTest;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Network;
 
-class NetworkTest extends TestCase
+class NetworkTest extends VonageTestCase
 {
     public function testNetworkArrayAccess(): void
     {

--- a/test/Numbers/ClientTest.php
+++ b/test/Numbers/ClientTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\Numbers;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -27,7 +27,7 @@ use VonageTest\Psr7AssertionTrait;
 use function fopen;
 use function is_null;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Numbers/Filter/AvailableNumbersTest.php
+++ b/test/Numbers/Filter/AvailableNumbersTest.php
@@ -4,10 +4,10 @@ namespace VonageTest\Numbers\Filter;
 
 use InvalidArgumentException;
 use Vonage\Numbers\Number;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Numbers\Filter\AvailableNumbers;
 
-class AvailableNumbersTest extends TestCase
+class AvailableNumbersTest extends VonageTestCase
 {
     /**
      * @dataProvider numberTypes

--- a/test/Numbers/NumberTest.php
+++ b/test/Numbers/NumberTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace VonageTest\Numbers;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Application\Application;
 use Vonage\Client\Exception\Exception as ClientException;
 use Vonage\Numbers\Number;
@@ -19,7 +19,7 @@ use Vonage\Numbers\Number;
 use function file_get_contents;
 use function json_decode;
 
-class NumberTest extends TestCase
+class NumberTest extends VonageTestCase
 {
     /**
      * @var Number;

--- a/test/Redact/ClientTest.php
+++ b/test/Redact/ClientTest.php
@@ -12,8 +12,9 @@ declare(strict_types=1);
 namespace VonageTest\Redact;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Vonage\Client;
@@ -24,9 +25,10 @@ use VonageTest\Psr7AssertionTrait;
 
 use function fopen;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
+
 
     /**
      * @var APIResource

--- a/test/Response/MessageTest.php
+++ b/test/Response/MessageTest.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace VonageTest\Response;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use RuntimeException;
 use Vonage\Response\Message;
 
 use function json_decode;
 
-class MessageTest extends TestCase
+class MessageTest extends VonageTestCase
 {
     protected $message;
 

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
 namespace VonageTest;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Response;
 use Vonage\Response\Message;
 
 use function json_decode;
 
-class ResponseTest extends TestCase
+class ResponseTest extends VonageTestCase
 {
     /**
      * @var Response

--- a/test/SMS/ClientTest.php
+++ b/test/SMS/ClientTest.php
@@ -13,7 +13,7 @@ namespace VonageTest\SMS;
 
 use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -29,7 +29,7 @@ use function fopen;
 use function json_decode;
 use function str_repeat;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/SMS/ExceptionErrorHandlerTest.php
+++ b/test/SMS/ExceptionErrorHandlerTest.php
@@ -14,13 +14,13 @@ namespace VonageTest\SMS;
 use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response\JsonResponse;
 use Laminas\Diactoros\ResponseFactory;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client\Exception\Request as RequestException;
 use Vonage\Client\Exception\Server as ServerException;
 use Vonage\Client\Exception\ThrottleException;
 use Vonage\SMS\ExceptionErrorHandler;
 
-class ExceptionErrorHandlerTest extends TestCase
+class ExceptionErrorHandlerTest extends VonageTestCase
 {
     /**
      * @throws RequestException

--- a/test/SMS/Message/BinaryTest.php
+++ b/test/SMS/Message/BinaryTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\SMS\Message;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\SMS\Message\Binary;
 
-class BinaryTest extends TestCase
+class BinaryTest extends VonageTestCase
 {
     public function testCanCreateBinaryMessage(): void
     {

--- a/test/SMS/Message/SMSTest.php
+++ b/test/SMS/Message/SMSTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace VonageTest\SMS\Message;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\SMS\Message\SMS;
 
-class SMSTest extends TestCase
+class SMSTest extends VonageTestCase
 {
     public function testCanSetUnicodeType(): void
     {

--- a/test/SMS/Message/VcalTest.php
+++ b/test/SMS/Message/VcalTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\SMS\Message;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\SMS\Message\Vcal;
 
-class VcalTest extends TestCase
+class VcalTest extends VonageTestCase
 {
     public function testCanCreateVcalMessage(): void
     {

--- a/test/SMS/Message/VcardTest.php
+++ b/test/SMS/Message/VcardTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\SMS\Message;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\SMS\Message\Vcard;
 
-class VcardTest extends TestCase
+class VcardTest extends VonageTestCase
 {
     public function testCanCreateVcardMessage(): void
     {

--- a/test/SMS/Message/WAPPushTest.php
+++ b/test/SMS/Message/WAPPushTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\SMS\Message;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\SMS\Message\WAPPush;
 
-class WAPPushTest extends TestCase
+class WAPPushTest extends VonageTestCase
 {
     public function testCanCreateWAPMessage(): void
     {

--- a/test/SMS/Webhook/DeliveryReceiptTest.php
+++ b/test/SMS/Webhook/DeliveryReceiptTest.php
@@ -15,7 +15,7 @@ use Exception;
 use InvalidArgumentException;
 use Laminas\Diactoros\Request\Serializer;
 use Laminas\Diactoros\ServerRequest;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\SMS\Webhook\DeliveryReceipt;
 use Vonage\SMS\Webhook\Factory;
 
@@ -23,7 +23,7 @@ use function file_get_contents;
 use function json_decode;
 use function parse_str;
 
-class DeliveryReceiptTest extends TestCase
+class DeliveryReceiptTest extends VonageTestCase
 {
     public function testCanCreateFromGetServerRequest(): void
     {

--- a/test/SMS/Webhook/InboundSMSTest.php
+++ b/test/SMS/Webhook/InboundSMSTest.php
@@ -15,7 +15,7 @@ use Exception;
 use InvalidArgumentException;
 use Laminas\Diactoros\Request\Serializer;
 use Laminas\Diactoros\ServerRequest;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use RuntimeException;
 use Vonage\SMS\Webhook\Factory;
 use Vonage\SMS\Webhook\InboundSMS;
@@ -24,7 +24,7 @@ use function file_get_contents;
 use function json_decode;
 use function parse_str;
 
-class InboundSMSTest extends TestCase
+class InboundSMSTest extends VonageTestCase
 {
     public function testCanCreateFromFormPostServerRequest(): void
     {

--- a/test/Secrets/ClientTest.php
+++ b/test/Secrets/ClientTest.php
@@ -8,11 +8,11 @@ use Vonage\Secrets\Client;
 use Vonage\Secrets\Secret;
 use VonageTest\HTTPTestTrait;
 use Vonage\Client\APIResource;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Client as VonageClient;
 use Psr\Http\Message\RequestInterface;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use HTTPTestTrait;
 

--- a/test/User/CollectionTest.php
+++ b/test/User/CollectionTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\User;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -25,7 +25,7 @@ use Vonage\User\User;
 use function fopen;
 use function json_encode;
 
-class CollectionTest extends TestCase
+class CollectionTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Verify/ClientTest.php
+++ b/test/Verify/ClientTest.php
@@ -13,7 +13,7 @@ namespace VonageTest\Verify;
 
 use InvalidArgumentException;
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -30,7 +30,7 @@ use function call_user_func_array;
 use function fopen;
 use function serialize;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Verify/ExceptionErrorHandlerTest.php
+++ b/test/Verify/ExceptionErrorHandlerTest.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 namespace VonageTest\Verify;
 
 use Laminas\Diactoros\Request;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Entity\Psr7Trait;
 use Laminas\Diactoros\Response;
 use Vonage\Client\Exception\Request as ExceptionRequest;
 use Vonage\Verify\ExceptionErrorHandler;
 
-class ExceptionErrorHandlerTest extends TestCase
+class ExceptionErrorHandlerTest extends VonageTestCase
 {
     use Psr7Trait;
 

--- a/test/Verify/RequestTest.php
+++ b/test/Verify/RequestTest.php
@@ -3,10 +3,10 @@
 namespace VonageTest\Verify;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Verify\Request;
 
-class RequestTest extends TestCase
+class RequestTest extends VonageTestCase
 {
     public function invalidDataDataProvider(): array
     {

--- a/test/Verify/VerificationTest.php
+++ b/test/Verify/VerificationTest.php
@@ -14,7 +14,7 @@ namespace VonageTest\Verify;
 use DateTime;
 use Exception;
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Vonage\Client\Exception\Exception as ClientException;
@@ -30,7 +30,7 @@ use function is_null;
 use function serialize;
 use function unserialize;
 
-class VerificationTest extends TestCase
+class VerificationTest extends VonageTestCase
 {
     /**
      * @var string

--- a/test/Voice/Call/CallTest.php
+++ b/test/Voice/Call/CallTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\Call;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Call\Call;
 
-class CallTest extends TestCase
+class CallTest extends VonageTestCase
 {
     /**
      * @var Call

--- a/test/Voice/CallTest.php
+++ b/test/Voice/CallTest.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
 namespace VonageTest\Voice;
 
 use Exception;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Call;
 
 use function file_get_contents;
 use function json_decode;
 
-class CallTest extends TestCase
+class CallTest extends VonageTestCase
 {
     /**
      * @throws Exception

--- a/test/Voice/ClientTest.php
+++ b/test/Voice/ClientTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace VonageTest\Voice;
 
 use Laminas\Diactoros\Response;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Prophecy\Argument;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -33,7 +33,7 @@ use function fopen;
 use function json_decode;
 use function json_encode;
 
-class ClientTest extends TestCase
+class ClientTest extends VonageTestCase
 {
     use Psr7AssertionTrait;
 

--- a/test/Voice/Endpoint/AppTest.php
+++ b/test/Voice/Endpoint/AppTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\Endpoint;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Endpoint\App;
 
-class AppTest extends TestCase
+class AppTest extends VonageTestCase
 {
     public function testSetsUsernameAtCreation(): void
     {

--- a/test/Voice/Endpoint/EndpointFactoryTest.php
+++ b/test/Voice/Endpoint/EndpointFactoryTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\Endpoint;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use RuntimeException;
 use Vonage\Voice\Endpoint\App;
 use Vonage\Voice\Endpoint\EndpointFactory;
@@ -20,7 +20,7 @@ use Vonage\Voice\Endpoint\SIP;
 use Vonage\Voice\Endpoint\VBC;
 use Vonage\Voice\Endpoint\Websocket;
 
-class EndpointFactoryTest extends TestCase
+class EndpointFactoryTest extends VonageTestCase
 {
     public function testCanCreateAppEndpoint(): void
     {

--- a/test/Voice/Endpoint/PhoneTest.php
+++ b/test/Voice/Endpoint/PhoneTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\Endpoint;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Endpoint\Phone;
 
-class PhoneTest extends TestCase
+class PhoneTest extends VonageTestCase
 {
     /**
      * @var string

--- a/test/Voice/Endpoint/SipTest.php
+++ b/test/Voice/Endpoint/SipTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\Endpoint;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Endpoint\SIP;
 
-class SipTest extends TestCase
+class SipTest extends VonageTestCase
 {
     /**
      * @var string

--- a/test/Voice/Endpoint/VBCTest.php
+++ b/test/Voice/Endpoint/VBCTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\Endpoint;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Endpoint\VBC;
 
-class VBCTest extends TestCase
+class VBCTest extends VonageTestCase
 {
     public function testSetsExtensionAtCreation(): void
     {

--- a/test/Voice/Endpoint/WebsocketTest.php
+++ b/test/Voice/Endpoint/WebsocketTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\Endpoint;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Endpoint\Websocket;
 
-class WebsocketTest extends TestCase
+class WebsocketTest extends VonageTestCase
 {
     /**
      * @var string

--- a/test/Voice/Filter/VoiceFilterTest.php
+++ b/test/Voice/Filter/VoiceFilterTest.php
@@ -15,10 +15,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Filter\VoiceFilter;
 
-class VoiceFilterTest extends TestCase
+class VoiceFilterTest extends VonageTestCase
 {
     /**
      * @throws Exception

--- a/test/Voice/Message/CallbackTest.php
+++ b/test/Voice/Message/CallbackTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace VonageTest\Voice\Message;
 
 use DateTime;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Message\Callback;
 
-class CallbackTest extends TestCase
+class CallbackTest extends VonageTestCase
 {
     protected $data = [
         'call-id' => '1234abcd',

--- a/test/Voice/Message/MessageTest.php
+++ b/test/Voice/Message/MessageTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\Message;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Message\Message;
 
-class MessageTest extends TestCase
+class MessageTest extends VonageTestCase
 {
     /**
      * @var Message

--- a/test/Voice/NCCO/Action/ConnectTest.php
+++ b/test/Voice/NCCO/Action/ConnectTest.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
 namespace VonageTest\Voice\NCCO\Action;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Endpoint\EndpointInterface;
 use Vonage\Voice\Endpoint\Phone;
 use Vonage\Voice\NCCO\Action\Connect;
 use Vonage\Voice\Webhook;
 
-class ConnectTest extends TestCase
+class ConnectTest extends VonageTestCase
 {
     /**
      * @var EndpointInterface

--- a/test/Voice/NCCO/Action/ConversationTest.php
+++ b/test/Voice/NCCO/Action/ConversationTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\NCCO\Action;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\NCCO\Action\Conversation;
 use Vonage\Voice\Webhook;
 
-class ConversationTest extends TestCase
+class ConversationTest extends VonageTestCase
 {
     public function testSimpleSetup(): void
     {

--- a/test/Voice/NCCO/Action/InputTest.php
+++ b/test/Voice/NCCO/Action/InputTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\NCCO\Action;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use RuntimeException;
 use Vonage\Voice\NCCO\Action\Input;
 
-class InputTest extends TestCase
+class InputTest extends VonageTestCase
 {
     public function testSpeechSettingsGenerateCorrectNCCO(): void
     {

--- a/test/Voice/NCCO/Action/NotifyTest.php
+++ b/test/Voice/NCCO/Action/NotifyTest.php
@@ -12,11 +12,11 @@ declare(strict_types=1);
 namespace VonageTest\Voice\NCCO\Action;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\NCCO\Action\Notify;
 use Vonage\Voice\Webhook;
 
-class NotifyTest extends TestCase
+class NotifyTest extends VonageTestCase
 {
     public function testCanSetAdditionalInformation(): void
     {

--- a/test/Voice/NCCO/Action/RecordTest.php
+++ b/test/Voice/NCCO/Action/RecordTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace VonageTest\Voice\NCCO\Action;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\NCCO\Action\Record;
 
-class RecordTest extends TestCase
+class RecordTest extends VonageTestCase
 {
     public function testWebhookMethodCanBeSetInFactory(): void
     {

--- a/test/Voice/NCCO/Action/StreamTest.php
+++ b/test/Voice/NCCO/Action/StreamTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\NCCO\Action;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\NCCO\Action\Stream;
 
-class StreamTest extends TestCase
+class StreamTest extends VonageTestCase
 {
     public function testSimpleSetup(): void
     {

--- a/test/Voice/NCCO/Action/TalkTest.php
+++ b/test/Voice/NCCO/Action/TalkTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\NCCO\Action;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\NCCO\Action\Talk;
 
-class TalkTest extends TestCase
+class TalkTest extends VonageTestCase
 {
     public function testSimpleSetup(): void
     {

--- a/test/Voice/NCCO/NCCOFactoryTest.php
+++ b/test/Voice/NCCO/NCCOFactoryTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace VonageTest\Voice\NCCO;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\NCCO\NCCOFactory;
 
-class NCCOFactoryTest extends TestCase
+class NCCOFactoryTest extends VonageTestCase
 {
     public function testThrowsExceptionWithBadAction(): void
     {

--- a/test/Voice/NCCO/NCCOTest.php
+++ b/test/Voice/NCCO/NCCOTest.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
 
 namespace VonageTest\Voice\NCCO;
 
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\NCCO\Action\Record;
 use Vonage\Voice\NCCO\NCCO;
 
 use function json_decode;
 use function json_encode;
 
-class NCCOTest extends TestCase
+class NCCOTest extends VonageTestCase
 {
     public function testCanCreateNCCOFromArray(): void
     {

--- a/test/Voice/OutboundCallTest.php
+++ b/test/Voice/OutboundCallTest.php
@@ -12,11 +12,11 @@ declare(strict_types=1);
 namespace VonageTest\Voice;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Endpoint\Phone;
 use Vonage\Voice\OutboundCall;
 
-class OutboundCallTest extends TestCase
+class OutboundCallTest extends VonageTestCase
 {
     public function testMachineDetectionThrowsExceptionOnBadValue(): void
     {

--- a/test/Voice/Webhook/FactoryTest.php
+++ b/test/Voice/Webhook/FactoryTest.php
@@ -17,7 +17,7 @@ use Exception;
 use InvalidArgumentException;
 use Laminas\Diactoros\Request\Serializer;
 use Laminas\Diactoros\ServerRequest;
-use PHPUnit\Framework\TestCase;
+use VonageTest\VonageTestCase;
 use Vonage\Voice\Webhook\Answer;
 use Vonage\Voice\Webhook\Error;
 use Vonage\Voice\Webhook\Event;
@@ -31,7 +31,7 @@ use function file_get_contents;
 use function json_decode;
 use function parse_str;
 
-class FactoryTest extends TestCase
+class FactoryTest extends VonageTestCase
 {
     /**
      * @throws Exception

--- a/test/VonageTestCase.php
+++ b/test/VonageTestCase.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace VonageTest;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+class VonageTestCase extends TestCase
+{
+    use ProphecyTrait;
+}


### PR DESCRIPTION
## Description
The test suite output has been clogged with a large amount of depreciation notices for the same issue for some time. This PR will solve this.

## Motivation and Context
PHPUnit will throw the following deprecation:
PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10
In order to fix this, we have to move this method into a new trait. This trait requires a new package, which in turn means the minimum PHP version MUST be bumped up to 7.4. 7.4 has currently just entered LTS.

We are keeping 7.2 as a minimum requirement for production (although by v3 this will likely be bumped up) but adding the minimum PHP version to be 7.4 to allow PHPUnit to complete without deprecations.

Due to the nature of this being my second contribution, I have also modified the packagist details to list me as the sole new maintainer.

## How Has This Been Tested?
This PR updates the test suite itself, so its very aim is to make sure the test suite passes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
