### PR TITLE
Country code prefix fix for Number Insight

### DIFF
--- a/src/Insights/Basic.php
+++ b/src/Insights/Basic.php
@@ -62,9 +62,9 @@ class Basic implements JsonSerializable, JsonUnserializableInterface, ArrayAcces
         return $this->data['country_name'];
     }
 
-    public function getCountryPrefix(): int
+    public function getCountryPrefix(): string
     {
-        return (int)$this->data['country_prefix'];
+        return $this->data['country_prefix'];
     }
 
     /**

--- a/src/Insights/Basic.php
+++ b/src/Insights/Basic.php
@@ -64,7 +64,7 @@ class Basic implements JsonSerializable, JsonUnserializableInterface, ArrayAcces
 
     public function getCountryPrefix(): int
     {
-        return $this->data['country_prefix'];
+        return (int)$this->data['country_prefix'];
     }
 
     /**

--- a/test/Insights/BasicTest.php
+++ b/test/Insights/BasicTest.php
@@ -63,7 +63,7 @@ class BasicTest extends VonageTestCase
                 'country_code' => 'GB',
                 'country_code_iso3' => 'GBR',
                 'country_name' => 'United Kingdom',
-                'country_prefix' => 44,
+                'country_prefix' => '44',
         ];
 
         $basic1 = new Basic($inputBasic1['national_format_number']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Country code return type is listed as an int, but is actually a string. In order to preserve leading 0's, it should remain a string.

## Motivation and Context
As reported in #292 , this fixes that bug.

## How Has This Been Tested?
Existing tests changed to return a string. Not worth refactoring these tests (array access needs to be deprecated on this class) as v3 evolution will cover it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
