### PR TITLE
Allow psr/log 2.0 (#299)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "psr/container": "^1.0",
     "psr/http-client-implementation": "^1.0",
     "vonage/nexmo-bridge": "^0.1.0",
-    "psr/log": "^1.1"
+    "psr/log": "^1.1|^2.0"
   },
   "require-dev": {
     "php": ">=7.4",


### PR DESCRIPTION
Allow psr/log 2.0

## How Has This Been Tested?

The version 2 adds type-hints but should not break anything, because children classes don't have to implement those argument type hints (diff: https://github.com/php-fig/log/compare/1.1.4...2.0.0). It's not a BC.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

(none of those)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
