### PR TITLE
Allow psr/log v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "psr/container": "^1.0 | ^2.0",
     "psr/http-client-implementation": "^1.0",
     "vonage/nexmo-bridge": "^0.1.0",
-    "psr/log": "^1.1|^2.0"
+    "psr/log": "^1.1|^2.0|^3.0"
   },
   "require-dev": {
     "php": "~7.4 || ~8.0 || ~8.1",


### PR DESCRIPTION
## Description
Allow support for psr/log v3.0

## Motivation and Context
Atm, this is preventing people from upgrading to vonage-notification-channel when they have psr/log installed: https://github.com/laravel/vonage-notification-channel/issues/56

## How Has This Been Tested?
I'm relying on this library's test suite.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
