### PR TITLE
Added fix for php 8.1 serialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "kingcoen/client-core",
+  "name": "vonage/client-core",
   "type": "library",
   "description": "PHP Client for using Vonage's API.",
   "homepage": "https://developer.nexmo.com",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "vonage/client-core",
+  "name": "kingcoen/client-core",
   "type": "library",
   "description": "PHP Client for using Vonage's API.",
   "homepage": "https://developer.nexmo.com",

--- a/src/Verify/Verification.php
+++ b/src/Verify/Verification.php
@@ -611,7 +611,7 @@ class Verification implements VerificationInterface, Serializable, ArrayHydrateI
         );
     }
 
-    public function serialize(): string
+    public function __serialize(): string
     {
         $data = [
             'requestData' => $this->requestData
@@ -628,10 +628,7 @@ class Verification implements VerificationInterface, Serializable, ArrayHydrateI
         return serialize($data);
     }
 
-    /**
-     * @param $serialized
-     */
-    public function unserialize($serialized): void
+    public function __unserialize($serialized): void
     {
         $data = unserialize($serialized, [true]);
 
@@ -644,6 +641,19 @@ class Verification implements VerificationInterface, Serializable, ArrayHydrateI
         if (isset($data['response'])) {
             $this->response = ResponseSerializer::fromString($data['response']);
         }
+    }
+
+    public function serialize(): string
+    {
+        return $this->__serialize();
+    }
+
+    /**
+     * @param $serialized
+     */
+    public function unserialize($serialized): void
+    {
+        $this->__unserialize($serialized);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Error: Vonage\Verify\Verification implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize()

## Motivation and Context
On the Verification the implementation is missing for PHP 8.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
