### PR TITLE
Verify Blocked Number Handling

### DIFF
--- a/src/Client/Exception/Request.php
+++ b/src/Client/Exception/Request.php
@@ -18,4 +18,27 @@ class Request extends Exception
 {
     use HasEntityTrait;
     use Psr7Trait;
+
+    protected string $requestId;
+    protected string $networkId;
+
+    public function setRequestId(string $requestId): void
+    {
+        $this->requestId = $requestId;
+    }
+
+    public function getRequestId(): string
+    {
+        return $this->requestId;
+    }
+
+    public function setNetworkId(string $networkId): void
+    {
+        $this->networkId = $networkId;
+    }
+
+    public function getNetworkId(): string
+    {
+        return $this->networkId;
+    }
 }

--- a/src/Verify/Client.php
+++ b/src/Verify/Client.php
@@ -341,6 +341,15 @@ class Client implements ClientAwareInterface, APIClient
             default:
                 $e = new ClientException\Request($data['error_text'], (int)$data['status']);
                 $e->setEntity($data);
+
+                if (array_key_exists('request_id', $data)) {
+                    $e->setRequestId($data['request_id']);
+                }
+
+                if (array_key_exists('network', $data)) {
+                    $e->setNetworkId($data['network']);
+                }
+
                 break;
         }
 

--- a/test/Verify/ClientTest.php
+++ b/test/Verify/ClientTest.php
@@ -313,6 +313,35 @@ class ClientTest extends VonageTestCase
     /**
      * @throws ClientExceptionInterface
      * @throws Client\Exception\Exception
+     * @throws ServerException
+     */
+    public function testStartThrowsExceptionAndHandlesConcurrentVerifications(): void
+    {
+        $response = $this->setupClientForStart('start-error-concurrent');
+
+        try {
+            @$this->client->start(
+                [
+                    'number' => '14845551212',
+                    'brand' => 'Test Verify'
+                ]
+            );
+
+            self::fail('did not throw exception');
+        } catch (Client\Exception\Request $e) {
+            $this->assertEquals('10', $e->getCode());
+            $this->assertEquals(
+                'Concurrent verifications to the same number are not allowed',
+                $e->getMessage()
+            );
+            $this->assertEquals('abcdef0123456789abcdef0123456789', $e->getRequestId());
+            $this->assertSame($response, @$e->getEntity()->getResponse());
+        }
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws Client\Exception\Exception
      * @throws Client\Exception\Request
      */
     public function testStartThrowsServerException(): void

--- a/test/Verify/ClientTest.php
+++ b/test/Verify/ClientTest.php
@@ -285,6 +285,34 @@ class ClientTest extends VonageTestCase
     /**
      * @throws ClientExceptionInterface
      * @throws Client\Exception\Exception
+     * @throws ServerException
+     */
+    public function testStartThrowsExceptionAndHandlesBlock(): void
+    {
+        $response = $this->setupClientForStart('start-error-blocked');
+
+        try {
+            @$this->client->start(
+                [
+                    'number' => '14845551212',
+                    'brand' => 'Test Verify'
+                ]
+            );
+
+            self::fail('did not throw exception');
+        } catch (Client\Exception\Request $e) {
+            $this->assertEquals('7', $e->getCode());
+            $this->assertEquals(
+                'The number you are trying to verify is blacklisted for verification',
+                $e->getMessage()
+            );
+            $this->assertSame($response, @$e->getEntity()->getResponse());
+        }
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws Client\Exception\Exception
      * @throws Client\Exception\Request
      */
     public function testStartThrowsServerException(): void

--- a/test/Verify/responses/start-error-blocked.json
+++ b/test/Verify/responses/start-error-blocked.json
@@ -1,0 +1,5 @@
+{
+  "status": "7",
+  "error_text": "The number you are trying to verify is blacklisted for verification",
+  "network": "25503"
+}

--- a/test/Verify/responses/start-error-concurrent.json
+++ b/test/Verify/responses/start-error-concurrent.json
@@ -1,0 +1,5 @@
+{
+  "status": "10",
+  "request_id": "abcdef0123456789abcdef0123456789",
+  "error_text": "Concurrent verifications to the same number are not allowed"
+}


### PR DESCRIPTION
New verify errors are being thrown. We need to make sure the SDK can handle them.

## Description
A new error is thrown when a number is blocked that has a different structure to other Verify API errors.
I have added the new payload in as a fixture and tests that the Exception can be thrown and parsed correctly.

## How Has This Been Tested?
Relevant test added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
