### PR TITLE
remove outdated docs

### DIFF
--- a/src/Voice/NCCO/Action/Talk.php
+++ b/src/Voice/NCCO/Action/Talk.php
@@ -20,32 +20,32 @@ class Talk implements ActionInterface
     /**
      * @var bool
      */
-    protected $bargeIn;
+    protected bool $bargeIn;
 
     /**
      * @var string
      */
-    protected $language;
+    protected string $language;
 
     /**
      * @var int
      */
-    protected $languageStyle = 0;
+    protected int $languageStyle = 0;
 
     /**
      * @var float
      */
-    protected $level;
+    protected float $level;
 
     /**
      * @var int
      */
-    protected $loop;
+    protected int $loop;
 
     /**
-     * @var string
+     * @var string|null
      */
-    protected $text;
+    protected ?string $text;
 
     public function __construct(string $text = null)
     {
@@ -54,7 +54,7 @@ class Talk implements ActionInterface
 
     /**
      * @param string $text
-     * @param array{text: string, bargeIn?: bool, level?: float, loop?: int, voiceName?: string} $data
+     * @param array{text: string, bargeIn?: bool, level?: float, loop?: int} $data
      * @return Talk
      */
     public static function factory(string $text, array $data): Talk
@@ -111,7 +111,7 @@ class Talk implements ActionInterface
     }
 
     /**
-     * @return array{action: string, bargeIn: bool, level: float, loop: int, text: string, voiceName: string}
+     * @return array{action: string, bargeIn: bool, level: float, loop: int, text: string}
      */
     public function jsonSerialize(): array
     {
@@ -148,7 +148,7 @@ class Talk implements ActionInterface
     }
 
     /**
-     * @return array{action: string, bargeIn: bool, level: string, loop: string, text: string, voiceName: string, language: string, style: string}
+     * @return array{action: string, bargeIn: bool, level: string, loop: string, text: string, language: string, style: string}
      */
     public function toNCCOArray(): array
     {

--- a/src/Voice/NCCO/Action/Talk.php
+++ b/src/Voice/NCCO/Action/Talk.php
@@ -17,19 +17,19 @@ use function is_null;
 
 class Talk implements ActionInterface
 {
-    protected bool $bargeIn;
+    protected bool $bargeIn = false;
 
-    protected string $language;
+    protected string $language = '';
 
     protected int $languageStyle = 0;
 
-    protected float $level;
+    protected ?float $level = 0;
 
-    protected int $loop;
+    protected int $loop = 1;
 
-    protected ?string $text;
+    protected ?string $text = '';
 
-    protected bool $premium;
+    protected bool $premium = false;
 
     public function __construct(string $text = null)
     {

--- a/src/Voice/NCCO/Action/Talk.php
+++ b/src/Voice/NCCO/Action/Talk.php
@@ -17,35 +17,19 @@ use function is_null;
 
 class Talk implements ActionInterface
 {
-    /**
-     * @var bool
-     */
     protected bool $bargeIn;
 
-    /**
-     * @var string
-     */
     protected string $language;
 
-    /**
-     * @var int
-     */
     protected int $languageStyle = 0;
 
-    /**
-     * @var float
-     */
     protected float $level;
 
-    /**
-     * @var int
-     */
     protected int $loop;
 
-    /**
-     * @var string|null
-     */
     protected ?string $text;
+
+    protected bool $premium;
 
     public function __construct(string $text = null)
     {
@@ -53,17 +37,28 @@ class Talk implements ActionInterface
     }
 
     /**
-     * @param string $text
-     * @param array{text: string, bargeIn?: bool, level?: float, loop?: int} $data
-     * @return Talk
+     * @param array{text: string, bargeIn?: bool, level?: float, style? : string, language?: string, premium?: bool, loop?: int} $data
      */
     public static function factory(string $text, array $data): Talk
     {
         $talk = new Talk($text);
 
+        if (array_key_exists('voiceName', $data)) {
+            trigger_error(
+                'voiceName is deprecated and will not be added to the NCCO',
+                E_USER_DEPRECATED
+            );
+        }
+
         if (array_key_exists('bargeIn', $data)) {
             $talk->setBargeIn(
                 filter_var($data['bargeIn'], FILTER_VALIDATE_BOOLEAN, ['flags' => FILTER_NULL_ON_FAILURE])
+            );
+        }
+
+        if (array_key_exists('premium', $data)) {
+            $talk->setPremium(
+                filter_var($data['premium'], FILTER_VALIDATE_BOOLEAN, ['flags' => FILTER_NULL_ON_FAILURE])
             );
         }
 
@@ -118,9 +113,6 @@ class Talk implements ActionInterface
         return $this->toNCCOArray();
     }
 
-    /**
-     * @return $this
-     */
     public function setBargeIn(bool $value): self
     {
         $this->bargeIn = $value;
@@ -137,9 +129,6 @@ class Talk implements ActionInterface
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setLoop(int $times): self
     {
         $this->loop = $times;
@@ -148,7 +137,22 @@ class Talk implements ActionInterface
     }
 
     /**
-     * @return array{action: string, bargeIn: bool, level: string, loop: string, text: string, language: string, style: string}
+     * @return $this
+     */
+    public function setPremium(bool $premium): self
+    {
+        $this->premium = $premium;
+
+        return $this;
+    }
+
+    public function getPremium(): bool
+    {
+        return $this->premium;
+    }
+
+    /**
+     * @return array{action: string, bargeIn: bool, level: string, loop: string, text: string, premium: string, language: string, style: string}
      */
     public function toNCCOArray(): array
     {
@@ -172,6 +176,10 @@ class Talk implements ActionInterface
         if ($this->getLanguage()) {
             $data['language'] = $this->getLanguage();
             $data['style'] = (string) $this->getLanguageStyle();
+        }
+
+        if (!is_null($this->getPremium())) {
+            $data['premium'] = $this->getPremium() ? 'true' : 'false';
         }
 
         return $data;

--- a/test/Voice/ClientTest.php
+++ b/test/Voice/ClientTest.php
@@ -173,6 +173,10 @@ class ClientTest extends VonageTestCase
                 [
                     'action' => 'talk',
                     'text' => 'Thank you for trying Vonage',
+                    'bargeIn' => 'false',
+                    'level' => '0',
+                    'loop' => '1',
+                    'premium' => 'false'
                 ]
             ],
             'length_timer' => '7200',
@@ -391,6 +395,10 @@ class ClientTest extends VonageTestCase
                     [
                         'action' => 'talk',
                         'text' => 'Thank you for trying Vonage',
+                        'bargeIn' => 'false',
+                        'level' => '0',
+                        'loop' => '1',
+                        'premium' => 'false'
                     ]
                 ]
             ],
@@ -489,6 +497,10 @@ class ClientTest extends VonageTestCase
         $id = 'ssf61863-4a51-ef6b-11e1-w6edebcf93bb';
         $payload = [
             'text' => 'This is sample text',
+            'bargeIn' => 'false',
+            'level' => '0',
+            'loop' => '1',
+            'premium' => 'false'
         ];
 
         $this->vonageClient->send(Argument::that(function (RequestInterface $request) use ($id, $payload) {

--- a/test/Voice/NCCO/Action/TalkTest.php
+++ b/test/Voice/NCCO/Action/TalkTest.php
@@ -21,6 +21,10 @@ class TalkTest extends VonageTestCase
         $this->assertSame([
             'action' => 'talk',
             'text' => 'Hello',
+            'bargeIn' => 'false',
+            'level' => '0',
+            'loop' => '1',
+            'premium' => 'false'
         ], (new Talk('Hello'))->jsonSerialize());
     }
 
@@ -32,6 +36,7 @@ class TalkTest extends VonageTestCase
             'bargeIn' => 'false',
             'level' => '0',
             'loop' => '1',
+            'premium' => 'false'
         ];
 
         $action = new Talk('Hello');
@@ -47,8 +52,12 @@ class TalkTest extends VonageTestCase
         $expected = [
             'action' => 'talk',
             'text' => 'Hello',
+            'bargeIn' => 'false',
+            'level' => '0',
+            'loop' => '1',
             'language' => 'en-US',
-            'style' => '0'
+            'style' => '0',
+            'premium' => 'false'
         ];
 
         $action = new Talk($expected['text']);
@@ -65,8 +74,12 @@ class TalkTest extends VonageTestCase
         $expected = [
             'action' => 'talk',
             'text' => 'Hello',
+            'bargeIn' => 'false',
+            'level' => '0',
+            'loop' => '1',
             'language' => 'en-US',
-            'style' => '3'
+            'style' => '3',
+            'premium' => 'false'
         ];
 
         $action = new Talk($expected['text']);
@@ -83,8 +96,12 @@ class TalkTest extends VonageTestCase
         $expected = [
             'action' => 'talk',
             'text' => 'Hello',
+            'bargeIn' => 'false',
+            'level' => '0',
+            'loop' => '1',
             'language' => 'en-US',
-            'style' => '0'
+            'style' => '0',
+            'premium' => 'false'
         ];
 
         $action = Talk::factory($expected['text'], $expected);
@@ -100,8 +117,12 @@ class TalkTest extends VonageTestCase
         $expected = [
             'action' => 'talk',
             'text' => 'Hello',
+            'bargeIn' => 'false',
+            'level' => '0',
+            'loop' => '1',
             'language' => 'en-US',
-            'style' => '3'
+            'style' => '3',
+            'premium' => 'false'
         ];
 
         $action = Talk::factory($expected['text'], $expected);

--- a/test/Voice/NCCO/NCCOTest.php
+++ b/test/Voice/NCCO/NCCOTest.php
@@ -31,6 +31,7 @@ class NCCOTest extends VonageTestCase
                 'text' => 'Thank you for trying Vonage',
                 'language' => 'en-US',
                 'style' => '0',
+                'premium' => 'false'
             ],
             [
                 'action' => 'record',


### PR DESCRIPTION
This PR removes outdated docblock information.

## Description
The Talk NCCO no longer takes `voiceName`, which was deprecated some time ago. This removes it from the docblocks.

## Motivation and Context
Misleading docs causing confusion for developers: see #328 

## How Has This Been Tested?
No tests required.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
