### PR TITLE
Feature/detect unicode mismatch

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -222,7 +222,7 @@ class Client implements LoggerAwareInterface
         );
 
         // Disable throwing E_USER_DEPRECATED notices by default, the user can turn it on during development
-        if (array_key_exists('show_deprecations', $this->options) && !$this->options['show_deprecations']) {
+        if (array_key_exists('show_deprecations', $this->options) && ($this->options['show_deprecations'] == true)) {
             set_error_handler(
                 static function (
                     int $errno,

--- a/src/SMS/Client.php
+++ b/src/SMS/Client.php
@@ -34,12 +34,26 @@ class Client implements APIClient
         return $this->api;
     }
 
+    public function isUnicode($message): bool
+    {
+        return strlen($message) !== strlen(utf8_decode($message));
+    }
+
     /**
      * @throws ClientExceptionInterface
      * @throws ClientException
      */
     public function send(Message $message): Collection
     {
+        if (($message->getType() === 'text') && $this->isUnicode($message->getMessage())) {
+            trigger_error(
+                "Sending unicode text SMS without setting the type parameter to 'unicode'.
+                    See https://developer.nexmo.com/messaging/sms for details, or email support@vonage.com 
+                    if you have any questions.",
+                E_USER_WARNING
+            );
+        }
+
         try {
             $response = $this->api->create($message->toArray(), '/sms/json');
 

--- a/src/SMS/Client.php
+++ b/src/SMS/Client.php
@@ -48,7 +48,7 @@ class Client implements APIClient
         if (($message->getType() === 'text') && $this->isUnicode($message->getMessage())) {
             trigger_error(
                 "Sending unicode text SMS without setting the type parameter to 'unicode'.
-                    See https://developer.nexmo.com/messaging/sms for details, or email support@vonage.com 
+                    See https://developer.vonage.com/messaging/sms for details, or email support@vonage.com 
                     if you have any questions.",
                 E_USER_WARNING
             );

--- a/test/SMS/ClientTest.php
+++ b/test/SMS/ClientTest.php
@@ -334,6 +334,29 @@ class ClientTest extends VonageTestCase
         $this->smsClient->sendTwoFactor('447700900000', 1245);
     }
 
+    public function testThrowsWarningSendingUnicodeAsTest(): void
+    {
+        $this->expectError();
+        $this->expectErrorMessage("Sending unicode text SMS without setting the type parameter to 'unicode'.
+                    See https://developer.vonage.com/messaging/sms for details, or email support@vonage.com 
+                    if you have any questions.");
+
+        $args = [
+            'to' => '447700900000',
+            'from' => '16105551212',
+            'text' => "♗ⳋ⤞ⶢⲍ⫓⵬⬕⫹⿁⊅⇧ⰾ⾵ ⃚",
+            'account-ref' => 'customer1234',
+            'client-ref' => 'my-personal-reference'
+        ];
+
+        $message = (new SMS($args['to'], $args['from'], $args['text']))
+            ->setClientRef($args['client-ref'])
+            ->setAccountRef($args['account-ref'])
+            ->setType('text');
+
+        $response = $this->smsClient->send($message);
+    }
+
     /**
      * @throws ClientExceptionInterface
      * @throws Client\Exception\Exception

--- a/test/SMS/ClientTest.php
+++ b/test/SMS/ClientTest.php
@@ -336,7 +336,11 @@ class ClientTest extends VonageTestCase
 
     public function testThrowsWarningSendingUnicodeAsTest(): void
     {
-        $this->expectError();
+        $this->vonageClient->send(Argument::that(function (Request $request) {
+            return true;
+        }))->willReturn($this->getResponse('send-success'));
+
+        $this->expectWarning();
         $this->expectErrorMessage("Sending unicode text SMS without setting the type parameter to 'unicode'.
                     See https://developer.vonage.com/messaging/sms for details, or email support@vonage.com 
                     if you have any questions.");

--- a/test/Verify/ClientTest.php
+++ b/test/Verify/ClientTest.php
@@ -72,7 +72,8 @@ class ClientTest extends VonageTestCase
 
         $this->client->setClient($client->reveal());
 
-        $mock = $this->getMockBuilder(Verification::class)
+        // Silencing a few instances were we use old deprecated construction
+        $mock = @$this->getMockBuilder(Verification::class)
             ->setConstructorArgs($construct)
             ->setMethods(['setClient'])
             ->getMock();


### PR DESCRIPTION
Adds a trigger warning when attempting to send wrong message type.

## Description
The Ruby SDK will throw a warning if you attempt to send a unicode message after you have set the SMS type to text. This PR replicates that behaviour.

## Motivation and Context
Progressive SDK improvements

## How Has This Been Tested?
New test has been added to make sure the warning is triggered, existing tests will cover when it should not be triggered.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
