### PR TITLE
Remove unused phpdocs - Account

### DIFF
--- a/src/Account/Balance.php
+++ b/src/Account/Balance.php
@@ -16,9 +16,6 @@ use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 class Balance implements
     ArrayHydrateInterface
 {
-    /**
-     * @var array
-     */
     protected array $data;
 
     public function __construct($balance, $autoReload)

--- a/test/Account/BalanceTest.php
+++ b/test/Account/BalanceTest.php
@@ -17,9 +17,6 @@ use Vonage\Client\Exception\Exception as ClientException;
 
 class BalanceTest extends VonageTestCase
 {
-    /**
-     * @var Balance
-     */
     protected Balance $balance;
 
     public function setUp(): void

--- a/test/Account/PrefixPriceTest.php
+++ b/test/Account/PrefixPriceTest.php
@@ -19,8 +19,6 @@ class PrefixPriceTest extends VonageTestCase
 {
     /**
      * @dataProvider prefixPriceProvider
-     *
-     * @param $prefixPrice
      */
     public function testFromArray($prefixPrice): void
     {
@@ -31,8 +29,6 @@ class PrefixPriceTest extends VonageTestCase
 
     /**
      * @dataProvider prefixPriceProvider
-     *
-     * @param $prefixPrice
      */
     public function testGetters($prefixPrice): void
     {
@@ -44,8 +40,6 @@ class PrefixPriceTest extends VonageTestCase
 
     /**
      * @dataProvider prefixPriceProvider
-     *
-     * @param $prefixPrice
      */
     public function testUsesCustomPriceForKnownNetwork($prefixPrice): void
     {

--- a/test/Account/SmsPriceTest.php
+++ b/test/Account/SmsPriceTest.php
@@ -18,8 +18,6 @@ class SmsPriceTest extends VonageTestCase
 {
     /**
      * @dataProvider smsPriceProvider
-     *
-     * @param $smsPrice
      */
     public function testFromArray($smsPrice): void
     {
@@ -31,8 +29,6 @@ class SmsPriceTest extends VonageTestCase
 
     /**
      * @dataProvider smsPriceProvider
-     *
-     * @param $smsPrice
      */
     public function testGetters($smsPrice): void
     {
@@ -45,8 +41,6 @@ class SmsPriceTest extends VonageTestCase
 
     /**
      * @dataProvider smsPriceProvider
-     *
-     * @param $smsPrice
      */
     public function testUsesCustomPriceForKnownNetwork($smsPrice): void
     {
@@ -55,8 +49,6 @@ class SmsPriceTest extends VonageTestCase
 
     /**
      * @dataProvider smsPriceProvider
-     *
-     * @param $smsPrice
      */
     public function testUsesDefaultPriceForUnknownNetwork($smsPrice): void
     {


### PR DESCRIPTION
Hello, I just removed some unused php docs on `src/Account` and `test/Account`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
