### PR TITLE
Remove unused phpdocs - Application

### DIFF
--- a/src/Application/Client.php
+++ b/src/Application/Client.php
@@ -28,14 +28,8 @@ class Client implements ClientAwareInterface, APIClient
 {
     use ClientAwareTrait;
 
-    /**
-     * @var APIResource
-     */
     protected APIResource $api;
 
-    /**
-     * @var HydratorInterface
-     */
     protected HydratorInterface $hydrator;
 
     public function __construct(APIResource $api, HydratorInterface $hydrator = null)

--- a/test/Application/ClientTest.php
+++ b/test/Application/ClientTest.php
@@ -42,14 +42,8 @@ class ClientTest extends VonageTestCase
 
     protected $vonageClient;
 
-    /**
-     * @var APIResource
-     */
     protected APIResource $apiClient;
 
-    /**
-     * @var ApplicationClient
-     */
     protected ApplicationClient $applicationClient;
 
     public function setUp(): void
@@ -75,9 +69,6 @@ class ClientTest extends VonageTestCase
 
     /**
      * @dataProvider getApplication
-     *
-     * @param $payload
-     * @param $id
      *
      * @throws ClientExceptionInterface
      * @throws ClientException
@@ -153,11 +144,6 @@ class ClientTest extends VonageTestCase
 
     /**
      * @dataProvider updateApplication
-     *
-     * @param $payload
-     * @param $method
-     * @param $id
-     * @param $expectedId
      */
     public function testUpdateApplication($payload, $method, $expectedId): void
     {
@@ -278,9 +264,6 @@ class ClientTest extends VonageTestCase
     /**
      * @dataProvider deleteApplication
      *
-     * @param $payload
-     * @param $id
-     *
      * @throws ClientExceptionInterface
      * @throws ClientException
      */
@@ -312,10 +295,6 @@ class ClientTest extends VonageTestCase
 
     /**
      * @dataProvider exceptions
-     *
-     * @param $method
-     * @param $response
-     * @param $code
      */
     public function testThrowsException($method, $response, $code): void
     {
@@ -373,9 +352,6 @@ class ClientTest extends VonageTestCase
 
     /**
      * @dataProvider createApplication
-     *
-     * @param $payload
-     * @param $method
      */
     public function testCreateApplication($payload, $method): void
     {


### PR DESCRIPTION
Hello, I just removed some unused php docs on `src/Application` and `test/Application`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
