### PR TITLE
Bug in ImageObject when using a caption

### DIFF
--- a/src/Messages/MessageObjects/ImageObject.php
+++ b/src/Messages/MessageObjects/ImageObject.php
@@ -33,7 +33,7 @@ class ImageObject implements ArrayHydrateInterface
         ];
 
         if ($this->caption) {
-            $returnArray[] = [
+            $returnArray += [
                 'caption' => $this->caption
             ];
         }


### PR DESCRIPTION
When using a caption the toArray() function currently adds a nested array to the $returnArray while the proposed change only adds the key/value to the $returnArray.

## Description
When using a caption the toArray() function currently adds a nested array to the $returnArray while the proposed change only adds the key/value to the $returnArray.

## How Has This Been Tested?
Made new classes in own project and tested the result with Vonage Sandbox. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
