### PR TITLE
Add separator to exception messages

### DIFF
--- a/src/Messages/ExceptionErrorHandler.php
+++ b/src/Messages/ExceptionErrorHandler.php
@@ -44,9 +44,9 @@ class ExceptionErrorHandler
         }
 
         if ($statusCode >= 500 && $statusCode <= 599) {
-            throw new ClientException\Server($responseBody['title'] . $responseBody['detail']);
+            throw new ClientException\Server($responseBody['title'] . ': ' . $responseBody['detail']);
         }
 
-        throw new ClientException\Request($responseBody['title'] . $responseBody['detail']);
+        throw new ClientException\Request($responseBody['title'] . ': ' . $responseBody['detail']);
     }
 }

--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -634,7 +634,7 @@ class ClientTest extends VonageTestCase
     public function testThrowsRequestErrorOnBadRequest(): void
     {
         $this->expectException(Client\Exception\Request::class);
-        $this->expectErrorMessage('The request body did not contain valid JSONUnexpected character (\'"\' (code 34)): was expecting comma to separate Object entries');
+        $this->expectErrorMessage('The request body did not contain valid JSON: Unexpected character (\'"\' (code 34)): was expecting comma to separate Object entries');
 
         $payload = [
             'to' => '447700900000',


### PR DESCRIPTION
## Description

Hey! This PR is only a small one and just adds `: ` between the title and body that are concatenated in the exception messages in the `Vonage\Messages\ExceptionErrorHandler`.

I'm really new to working with this package, so I apologise if I've not done this right, or if it's not needed!

## Motivation and Context

When I was working with the Laravel Vonage package trying to send a message, an exception was thrown because I'd passed an incorrect parameter. The exception's message read:

```
Invalid senderThe `from` parameter is invalid.
```

So I've copied the same approach that's been used on line 41 in that class and added the separator between the response body's title and body. This would change the above message to:

```
Invalid sender: The `from` parameter is invalid.
```

## How Has This Been Tested?

I've tested these changes by trying to send a WhatsApp message with some invalid parameters.

## Example Output or Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
