### PR TITLE
Move isGsm7 to static for other libraries

### DIFF
--- a/src/SMS/Message/SMS.php
+++ b/src/SMS/Message/SMS.php
@@ -30,9 +30,9 @@ class SMS extends OutboundMessage
         $this->setType($type);
     }
 
-    public function isGsm7(): bool
+    public static function isGsm7(string $message): bool
     {
-        return (bool)preg_match(self::GSM_7_PATTERN, $this->getMessage());
+        return (bool)preg_match(self::GSM_7_PATTERN, $message);
     }
 
     public function getContentId(): string
@@ -59,14 +59,14 @@ class SMS extends OutboundMessage
 
     public function getErrorMessage(): ?string
     {
-        if ($this->getType() === 'unicode' && $this->isGsm7()) {
+        if ($this->getType() === 'unicode' && self::isGsm7($this->getMessage())) {
             $this->setErrorMessage("You are sending a message as `unicode` when it could be `text` or a
             `text` type with unicode-only characters. This could result in increased billing - 
             See https://developer.vonage.com/messaging/sms for details, or email support@vonage.com if you have any 
             questions.");
         }
 
-        if ($this->getType() === 'text' && ! $this->isGsm7()) {
+        if ($this->getType() === 'text' && ! self::isGsm7($this->getMessage())) {
             $this->setErrorMessage("You are sending a message as `text` when contains unicode only 
             characters. This could result in encoding problems with the target device or increased billing - See 
             https://developer.vonage.com/messaging/sms for details, or email support@vonage.com if you have any 

--- a/test/SMS/Message/SMSTest.php
+++ b/test/SMS/Message/SMSTest.php
@@ -173,10 +173,9 @@ class SMSTest extends VonageTestCase
      * @dataProvider unicodeStringDataProvider
      * @return void
      */
-    public function testGsm7Identification(string $message, bool $expectedGsm7)
+    public function testGsm7Identification(string $message, bool $expectedGsm7): void
     {
-        $sms = new SMS('16105551212', '16105551212', $message);
-        $this->assertEquals($expectedGsm7, $sms->isGsm7());
+        $this->assertEquals($expectedGsm7, SMS::isGsm7($message));
     }
 
     public function unicodeStringDataProvider(): array


### PR DESCRIPTION
This PR moves the `isGsm7()` method as static so that it can be used as a helper method for users.

## Motivation and Context
Other libraries and users themselves might want to check the correct encoding before using the Client.

## How Has This Been Tested?
Existing tests migrated to new style.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
