### PR TITLE
Fix class name to identify client version

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -588,7 +588,7 @@ class Client implements LoggerAwareInterface
 
     protected function getVersion(): string
     {
-        return Versions::getVersion('vonage/client-core');
+        return InstalledVersions::getVersion('vonage/client-core');
     }
 
     public function getLogger(): ?LoggerInterface


### PR DESCRIPTION
Class "Vonage\Versions" not found (v 4.0.3 and 4.0.2 are unusable currently)

```php
return Versions::getVersion('vonage/client-core');
```

Regression after [#354](https://github.com/Vonage/vonage-php-sdk-core/pull/354)