### PR TITLE
Change logic to look for the text field to determine the type of webhook

### DIFF
--- a/src/SMS/Webhook/DeliveryReceipt.php
+++ b/src/SMS/Webhook/DeliveryReceipt.php
@@ -270,7 +270,7 @@ class DeliveryReceipt
         return $this->price;
     }
 
-    public function getScts(): string
+    public function getScts(): ?string
     {
         return $this->scts;
     }

--- a/src/SMS/Webhook/Factory.php
+++ b/src/SMS/Webhook/Factory.php
@@ -29,7 +29,10 @@ class Factory extends WebhookFactory
      */
     public static function createFromArray(array $data)
     {
-        if (array_key_exists('scts', $data)) {
+        // We are dealing with only two webhooks here. One has the text field, one does not.
+        // A sort of if/else style block here smells a bit, ideally the backend needs to change.
+
+        if (!array_key_exists('text', $data)) {
             return new DeliveryReceipt($data);
         }
 


### PR DESCRIPTION
This PR Changes the logic when hydrating an incoming SMS webhook.

## Description
We have functionality to hydrate webhook requests from Vonage that can work out what the incoming hook type is: we do this because although the 

Previously, the SMS WebHook factory could hydrate an incoming request and hydrate it to the right object. This relied on a DeliveryReciept having an `scts` field, and an SMS matching all fields as described in the API spec.

`scts` no longer comes up when the delivery is a message type error of 11. Therefore, it's no longer a valid way of working out what kind of incoming request you have.

Instead, we now check to see if the `text` field is present. If it is not, it's a DeliveryReceipt. If all of the fields match what we expect, it's an incoming SMS. If it doesn't, the SDK throws an exception as we don't know what we're dealing with.

## Motivation and Context
Continued improvement of our SDKs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
