### PR TITLE
Bug/missing square bracket escape gsm7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,10 @@
   },
   "config": {
     "optimize-autoloader": true,
-    "preferred-install": "dist"
+    "preferred-install": "dist",
+    "allow-plugins": {
+      "php-http/discovery": true
+    }
   },
   "autoload": {
     "psr-4": {

--- a/src/SMS/Message/SMS.php
+++ b/src/SMS/Message/SMS.php
@@ -13,7 +13,7 @@ namespace Vonage\SMS\Message;
 
 class SMS extends OutboundMessage
 {
-    public const GSM_7_PATTERN = '/\A[\n\f\r !\"\#$%&\'()*+,-.\/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\][\\\\\^_abcdefghijklmnopqrstuvwxyz{\|}~ ¡£¤¥§¿ÄÅÆÇÉÑÖØÜßàäåæèéìñòöøùüΓΔΘΛΞΠΣΦΨΩ€]*\z/m';
+    public const GSM_7_CHARSET = "\n\f\r !\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~ ¡£¤¥§¿ÄÅÆÇÉÑÖØÜßàäåæèéìñòöøùüΓΔΘΛΞΠΣΦΨΩ€";
 
     protected ?string $contentId;
 
@@ -32,7 +32,8 @@ class SMS extends OutboundMessage
 
     public static function isGsm7(string $message): bool
     {
-        return (bool)preg_match(self::GSM_7_PATTERN, $message);
+        $fullPattern = "/\A[" . preg_quote(self::GSM_7_CHARSET, '/') . "]*\z/";
+        return (bool)preg_match($fullPattern, $message);
     }
 
     public function getContentId(): string

--- a/src/SMS/Message/SMS.php
+++ b/src/SMS/Message/SMS.php
@@ -13,7 +13,7 @@ namespace Vonage\SMS\Message;
 
 class SMS extends OutboundMessage
 {
-    public const GSM_7_PATTERN = '/\A[\n\f\r !\"\#$%&\'()*+,-.\/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\\^_abcdefghijklmnopqrstuvwxyz{\|}~ ¡£¤¥§¿ÄÅÆÇÉÑÖØÜßàäåæèéìñòöøùüΓΔΘΛΞΠΣΦΨΩ€]*\z/m';
+    public const GSM_7_PATTERN = '/\A[\n\f\r !\"\#$%&\'()*+,-.\/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\][\\\\\^_abcdefghijklmnopqrstuvwxyz{\|}~ ¡£¤¥§¿ÄÅÆÇÉÑÖØÜßàäåæèéìñòöøùüΓΔΘΛΞΠΣΦΨΩ€]*\z/m';
 
     protected ?string $contentId;
 
@@ -68,7 +68,7 @@ class SMS extends OutboundMessage
 
         if ($this->getType() === 'text' && ! self::isGsm7($this->getMessage())) {
             $this->setErrorMessage("You are sending a message as `text` when contains unicode only 
-            characters. This could result in encoding problems with the target device or increased billing - See 
+            characters. This could result in encoding problems with the target device - See 
             https://developer.vonage.com/messaging/sms for details, or email support@vonage.com if you have any 
             questions.");
         }

--- a/test/SMS/ClientTest.php
+++ b/test/SMS/ClientTest.php
@@ -413,7 +413,7 @@ class ClientTest extends VonageTestCase
 
         $this->expectWarning();
         $this->expectErrorMessage("You are sending a message as `text` when contains unicode only 
-            characters. This could result in encoding problems with the target device or increased billing - See 
+            characters. This could result in encoding problems with the target device - See 
             https://developer.vonage.com/messaging/sms for details, or email support@vonage.com if you have any 
             questions.");
 

--- a/test/SMS/Message/SMSTest.php
+++ b/test/SMS/Message/SMSTest.php
@@ -182,6 +182,7 @@ class SMSTest extends VonageTestCase
     {
         return [
             ['this is a text', true],
+            ['This is a text with some tasty characters: [test]', true],
             ['This is also a GSM7 text', true],
             ['This is a Çotcha', true],
             ['This is also a çotcha', true],


### PR DESCRIPTION
This PR fixes the GSM-7 regex, which was missing the square bracket character due to escaping issues.

## How Has This Been Tested?
The offending text, raised by the Laravel community has been 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
