### PR TITLE
added missing query string auth, add to account api

### DIFF
--- a/src/Account/ClientFactory.php
+++ b/src/Account/ClientFactory.php
@@ -14,6 +14,7 @@ namespace Vonage\Account;
 use Psr\Container\ContainerInterface;
 use Vonage\Client\APIResource;
 use Vonage\Client\Credentials\Handler\BasicHandler;
+use Vonage\Client\Credentials\Handler\BasicQueryHandler;
 
 class ClientFactory
 {
@@ -25,7 +26,7 @@ class ClientFactory
             ->setBaseUrl($accountApi->getClient()->getRestUrl())
             ->setIsHAL(false)
             ->setBaseUri('/account')
-            ->setAuthHandler(new BasicHandler())
+            ->setAuthHandler(new BasicQueryHandler())
         ;
 
         return new Client($accountApi);

--- a/src/Client/Credentials/Handler/BasicQueryHandler.php
+++ b/src/Client/Credentials/Handler/BasicQueryHandler.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Vonage\Client\Credentials\Handler;
+
+use Psr\Http\Message\RequestInterface;
+use Vonage\Client\Credentials\Basic;
+use Vonage\Client\Credentials\CredentialsInterface;
+
+class BasicQueryHandler extends AbstractHandler
+{
+    public function __invoke(RequestInterface $request, CredentialsInterface $credentials): RequestInterface
+    {
+        $credentials = $this->extract(Basic::class, $credentials);
+
+        return $request->withUri($request->getUri()->withQuery(http_build_query($credentials->asArray())));
+    }
+}

--- a/test/Account/ClientTest.php
+++ b/test/Account/ClientTest.php
@@ -56,6 +56,7 @@ class ClientTest extends VonageTestCase
         $this->api = new APIResource();
         $this->api->setBaseUrl('https://rest.nexmo.com')
             ->setIsHAL(false)
+            ->setAuthHandler(new Client\Credentials\Handler\BasicQueryHandler())
             ->setBaseUri('/account');
 
         $this->api->setClient($this->vonageClient->reveal());
@@ -162,6 +163,10 @@ class ClientTest extends VonageTestCase
             $this->assertEquals('/account/get-balance', $request->getUri()->getPath());
             $this->assertEquals('rest.nexmo.com', $request->getUri()->getHost());
             $this->assertEquals('GET', $request->getMethod());
+
+            $uri = $request->getUri();
+            $uriString = $uri->__toString();
+            $this->assertEquals('https://rest.nexmo.com/account/get-balance?api_key=abc&api_secret=def', $uriString);
 
             return true;
         }))->shouldBeCalledTimes(1)->willReturn($this->getResponse('get-balance'));

--- a/test/Client/Credentials/Handler/BasicQueryHandlerTest.php
+++ b/test/Client/Credentials/Handler/BasicQueryHandlerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace VonageTest\Client\Credentials\Handler;
+
+use Laminas\Diactoros\Request;
+use Vonage\Client\Credentials\Basic;
+use Vonage\Client\Credentials\Handler\BasicQueryHandler;
+use PHPUnit\Framework\TestCase;
+
+class BasicQueryHandlerTest extends TestCase
+{
+    public function testWillAddCredentialsToRequest(): void
+    {
+        $request = new Request('https://example.com');
+        $credentials = new Basic('abc', 'xyz');
+        $handler = new BasicQueryHandler();
+        $request = $handler($request, $credentials);
+
+        $uri = $request->getUri();
+        $uriString = $uri->__toString();
+        $this->assertEquals('https://example.com?api_key=abc&api_secret=xyz', $uriString);
+    }
+}


### PR DESCRIPTION
This PR introduces a new type of Auth handler - the Account API is one of the few APIs left that will only take auth via query parameters. Due to this, I have now added the new type of Handler and applied it to the Account Client.

## Motivation and Context
Fixes #368 

## How Has This Been Tested?
New tests for the handler.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
