### PR TITLE
Fix IterableAPICollection Auth Handling

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -141,8 +141,11 @@ class Client implements LoggerAwareInterface
     /**
      * Create a new API client using the provided credentials.
      */
-    public function __construct(CredentialsInterface $credentials, $options = [], ?ClientInterface $client = null)
-    {
+    public function __construct(
+        CredentialsInterface $credentials,
+        $options = [],
+        ?ClientInterface $client = null
+    ) {
         if (is_null($client)) {
             // Since the user did not pass a client, try and make a client
             // using the Guzzle 6 adapter or Guzzle 7 (depending on availability)

--- a/src/Entity/IterableAPICollection.php
+++ b/src/Entity/IterableAPICollection.php
@@ -474,6 +474,8 @@ class IterableAPICollection implements ClientAwareInterface, Iterator, Countable
         }
 
         $request = new Request($requestUri, 'GET');
+
+        // @TODO WARNING: isn't this a bug with the SDK? We're bypassing auth and using the client.
         $response = $this->client->send($request);
 
         $this->getApiResource()->setLastRequest($request);

--- a/src/Entity/IterableAPICollection.php
+++ b/src/Entity/IterableAPICollection.php
@@ -475,7 +475,10 @@ class IterableAPICollection implements ClientAwareInterface, Iterator, Countable
 
         $request = new Request($requestUri, 'GET');
 
-        // @TODO WARNING: isn't this a bug with the SDK? We're bypassing auth and using the client.
+        if ($this->getApiResource()->getAuthHandler()) {
+            $this->getApiResource()->addAuth($request);
+        }
+
         $response = $this->client->send($request);
 
         $this->getApiResource()->setLastRequest($request);

--- a/test/Insights/ClientTest.php
+++ b/test/Insights/ClientTest.php
@@ -49,6 +49,11 @@ class ClientTest extends VonageTestCase
     {
         $this->vonageClient = $this->prophesize(Client::class);
         $this->vonageClient->getApiUrl()->willReturn('http://api.nexmo.com');
+        $this->vonageClient->getCredentials()->willReturn(
+            new Client\Credentials\Container(
+                new Client\Credentials\Basic('abc', 'def'),
+            )
+        );
 
         $this->api = new APIResource();
         $this->api->setIsHAL(false);

--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -645,7 +645,7 @@ class ClientTest extends VonageTestCase
     public function testThrowsRequestErrorOnBadRequest(): void
     {
         $this->expectException(Client\Exception\Request::class);
-        $this->expectErrorMessage('The request body did not contain valid JSON: Unexpected character (\'"\' (code 34)): was expecting comma to separate Object entries');
+        $this->expectExceptionMessage('The request body did not contain valid JSON: Unexpected character (\'"\' (code 34)): was expecting comma to separate Object entries');
 
         $payload = [
             'to' => '447700900000',
@@ -671,7 +671,7 @@ class ClientTest extends VonageTestCase
     public function testThrowsRateLimit(): void
     {
         $this->expectException(Client\Exception\ThrottleException::class);
-        $this->expectErrorMessage('Rate Limit Hit: Please wait, then retry your request');
+        $this->expectExceptionMessage('Rate Limit Hit: Please wait, then retry your request');
 
         $payload = [
             'to' => '447700900000',


### PR DESCRIPTION
This PR fixes a major bug where Auth was not being handled in the IterableAPICollection

## Description
This is a hangover when moving the Auth system over to the handler types. The SDK has slowly being moving request logic out of the base Client that should not care what it receives to send over the wire - the request itself should be stitched together from the APIResource.

## Motivation and Context
Currently raised from an open bug (#376), so needs fixing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
