### PR TITLE
New Message Types

### DIFF
--- a/src/Messages/Channel/BaseMessage.php
+++ b/src/Messages/Channel/BaseMessage.php
@@ -17,6 +17,7 @@ abstract class BaseMessage implements Message
     public const MESSAGES_SUBTYPE_VIDEO = 'video';
     public const MESSAGES_SUBTYPE_FILE = 'file';
     public const MESSAGES_SUBTYPE_TEMPLATE = 'template';
+    public const MESSAGES_SUBTYPE_STICKER = 'sticker';
     public const MESSAGES_SUBTYPE_CUSTOM = 'custom';
 
     public function getClientRef(): ?string

--- a/src/Messages/Channel/Viber/MessageObjects/ViberActionObject.php
+++ b/src/Messages/Channel/Viber/MessageObjects/ViberActionObject.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Vonage\Messages\Channel\Viber\MessageObjects;
+
+use Vonage\Entity\Hydrator\ArrayHydrateInterface;
+
+class ViberActionObject implements ArrayHydrateInterface
+{
+    public function __construct(private string $url, private string $text = '')
+    {
+    }
+
+    public function fromArray(array $data): ViberActionObject
+    {
+        $this->url = $data['url'];
+        $this->text = $data['text'];
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'url' => $this->getUrl(),
+            'text' => $this->getText()
+        ];
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getText(): string
+    {
+        return $this->text;
+    }
+}

--- a/src/Messages/Channel/Viber/ViberFile.php
+++ b/src/Messages/Channel/Viber/ViberFile.php
@@ -2,48 +2,35 @@
 
 namespace Vonage\Messages\Channel\Viber;
 
-use Vonage\Messages\Channel\Viber\MessageObjects\ViberActionObject;
-use Vonage\Messages\MessageTraits\TextTrait;
+use Vonage\Messages\MessageObjects\FileObject;
 use Vonage\Messages\Channel\BaseMessage;
-
-class ViberText extends BaseMessage
+class ViberFile extends BaseMessage
 {
-    use TextTrait;
     use ViberServiceObjectTrait;
 
-    protected string $subType = BaseMessage::MESSAGES_SUBTYPE_TEXT;
     protected string $channel = 'viber_service';
+    protected string $subType = BaseMessage::MESSAGES_SUBTYPE_FILE;
 
     public function __construct(
         string $to,
         string $from,
-        string $message,
-        ?string $category = null,
-        ?int $ttl = null,
-        ?string $type = null,
-        ?ViberActionObject $viberActionObject = null,
+        protected FileObject $fileObject
     ) {
         $this->to = $to;
         $this->from = $from;
-        $this->text = $message;
-        $this->category = $category;
-        $this->ttl = $ttl;
-        $this->type = $type;
-        $this->action = $viberActionObject;
     }
 
     public function toArray(): array
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
-        $returnArray['text'] = $this->getText();
+        $returnArray['file'] = $this->fileObject->toArray();
 
         if ($this->requiresViberServiceObject()) {
             $this->getCategory() ? $returnArray['viber_service']['category'] = $this->getCategory(): null;
             $this->getTtl() ? $returnArray['viber_service']['ttl'] = $this->getTtl(): null;
             $this->getType() ? $returnArray['viber_service']['type'] = $this->getType(): null;
-            $this->getAction() ? $returnArray['viber_service']['action'] = $this->getAction()->toArray(): null;
         }
 
-        return array_filter($returnArray);
+        return $returnArray;
     }
 }

--- a/src/Messages/Channel/Viber/ViberImage.php
+++ b/src/Messages/Channel/Viber/ViberImage.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Messages\Channel\Viber;
 
+use Vonage\Messages\Channel\Viber\MessageObjects\ViberActionObject;
 use Vonage\Messages\MessageObjects\ImageObject;
 use Vonage\Messages\Channel\BaseMessage;
 
@@ -18,13 +19,15 @@ class ViberImage extends BaseMessage
         protected ImageObject $image,
         ?string $category = null,
         ?int $ttl = null,
-        ?string $type = null
+        ?string $type = null,
+        ?ViberActionObject $viberActionObject = null
     ) {
         $this->to = $to;
         $this->from = $from;
         $this->category = $category;
         $this->ttl = $ttl;
         $this->type = $type;
+        $this->action = $viberActionObject;
     }
 
     public function toArray(): array
@@ -33,9 +36,10 @@ class ViberImage extends BaseMessage
         $returnArray['image'] = $this->image->toArray();
 
         if ($this->requiresViberServiceObject()) {
-            $returnArray['viber_service']['category'] = $this->getCategory();
-            $returnArray['viber_service']['ttl'] = $this->getTtl();
-            $returnArray['viber_service']['type'] = $this->getType();
+            $this->getCategory() ? $returnArray['viber_service']['category'] = $this->getCategory(): null;
+            $this->getTtl() ? $returnArray['viber_service']['ttl'] = $this->getTtl(): null;
+            $this->getType() ? $returnArray['viber_service']['type'] = $this->getType(): null;
+            $this->getAction() ? $returnArray['viber_service']['action'] = $this->getAction()->toArray(): null;
         }
 
         return array_filter($returnArray);

--- a/src/Messages/Channel/Viber/ViberServiceObjectTrait.php
+++ b/src/Messages/Channel/Viber/ViberServiceObjectTrait.php
@@ -2,15 +2,18 @@
 
 namespace Vonage\Messages\Channel\Viber;
 
+use Vonage\Messages\Channel\Viber\MessageObjects\ViberActionObject;
+
 trait ViberServiceObjectTrait
 {
-    private ?string $category;
-    private ?int $ttl;
-    private ?string $type;
+    private ?string $category = null;
+    private ?int $ttl = null;
+    private ?string $type = null;
+    private ?ViberActionObject $action = null;
 
     public function requiresViberServiceObject(): bool
     {
-        return $this->getCategory() || $this->getTtl() || $this->getType();
+        return $this->getCategory() || $this->getTtl() || $this->getType() || $this->getAction();
     }
 
     public function getCategory(): ?string
@@ -18,9 +21,11 @@ trait ViberServiceObjectTrait
         return $this->category;
     }
 
-    public function setCategory(?string $category): void
+    public function setCategory(?string $category): static
     {
         $this->category = $category;
+
+        return $this;
     }
 
     public function getTtl(): ?int
@@ -28,9 +33,11 @@ trait ViberServiceObjectTrait
         return $this->ttl;
     }
 
-    public function setTtl(int $ttl): void
+    public function setTtl(int $ttl): static
     {
         $this->ttl = $ttl;
+
+        return $this;
     }
 
     public function getType(): ?string
@@ -38,8 +45,22 @@ trait ViberServiceObjectTrait
         return $this->type;
     }
 
-    public function setType(string $type): void
+    public function setType(string $type): static
     {
         $this->type = $type;
+
+        return $this;
+    }
+
+    public function getAction(): ?ViberActionObject
+    {
+        return $this->action;
+    }
+
+    public function setAction(ViberActionObject $viberActionObject): static
+    {
+        $this->action = $viberActionObject;
+
+        return $this;
     }
 }

--- a/src/Messages/Channel/Viber/ViberServiceObjectTrait.php
+++ b/src/Messages/Channel/Viber/ViberServiceObjectTrait.php
@@ -13,9 +13,6 @@ trait ViberServiceObjectTrait
         return $this->getCategory() || $this->getTtl() || $this->getType();
     }
 
-    /**
-     * @return string|null
-     */
     public function getCategory(): ?string
     {
         return $this->category;
@@ -26,33 +23,21 @@ trait ViberServiceObjectTrait
         $this->category = $category;
     }
 
-    /**
-     * @return int|null
-     */
     public function getTtl(): ?int
     {
         return $this->ttl;
     }
 
-    /**
-     * @param int|null $ttl
-     */
     public function setTtl(int $ttl): void
     {
         $this->ttl = $ttl;
     }
 
-    /**
-     * @return string|null
-     */
     public function getType(): ?string
     {
         return $this->type;
     }
 
-    /**
-     * @param string|null $type
-     */
     public function setType(string $type): void
     {
         $this->type = $type;

--- a/src/Messages/Channel/Viber/ViberVideo.php
+++ b/src/Messages/Channel/Viber/ViberVideo.php
@@ -17,16 +17,20 @@ class ViberVideo extends BaseMessage
     public function __construct(
         string $to,
         string $from,
+        string $thumbUrl,
         protected VideoObject $videoObject
     ) {
         $this->to = $to;
         $this->from = $from;
+        $this->thumbUrl = $thumbUrl;
     }
 
     public function toArray(): array
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
-        $returnArray['video'] = $this->videoObject->toArray();
+        $videoArray = $this->videoObject->toArray();
+        $videoArray['thumb_url'] = $this->thumbUrl;
+        $returnArray['video'] = $videoArray;
 
         return $returnArray;
     }

--- a/src/Messages/Channel/Viber/ViberVideo.php
+++ b/src/Messages/Channel/Viber/ViberVideo.php
@@ -13,6 +13,7 @@ class ViberVideo extends BaseMessage
 
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VIDEO;
     protected string $channel = 'viber_service';
+    protected string $thumbUrl = "";
 
     public function __construct(
         string $to,

--- a/src/Messages/Channel/Viber/ViberVideo.php
+++ b/src/Messages/Channel/Viber/ViberVideo.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Vonage\Messages\Channel\Viber;
+
+use Vonage\Messages\MessageObjects\VideoObject;
+use Vonage\Messages\MessageTraits\TextTrait;
+use Vonage\Messages\Channel\BaseMessage;
+
+class ViberVideo extends BaseMessage
+{
+    use TextTrait;
+    use ViberServiceObjectTrait;
+
+    protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VIDEO;
+    protected string $channel = 'viber_service';
+
+    public function __construct(
+        string $to,
+        string $from,
+        protected VideoObject $videoObject
+    ) {
+        $this->to = $to;
+        $this->from = $from;
+    }
+
+    public function toArray(): array
+    {
+        $returnArray = $this->getBaseMessageUniversalOutputArray();
+        $returnArray['video'] = $this->videoObject->toArray();
+
+        return $returnArray;
+    }
+}

--- a/src/Messages/Channel/WhatsApp/MessageObjects/StickerObject.php
+++ b/src/Messages/Channel/WhatsApp/MessageObjects/StickerObject.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Vonage\Messages\Channel\WhatsApp\MessageObjects;
+
+use Vonage\Entity\Hydrator\ArrayHydrateInterface;
+
+class StickerObject implements ArrayHydrateInterface
+{
+    public const STICKER_URL = 'url';
+    public  const STICKER_ID = 'id';
+
+    private array $allowedTypes = [
+        self::STICKER_URL,
+        self::STICKER_ID
+    ];
+
+    public function __construct(private string $type, private string $value = '')
+    {
+        if (! in_array($type, $this->allowedTypes, true)) {
+            throw new \InvalidArgumentException($type . ' is an invalid type of Sticker');
+        }
+    }
+
+    public function fromArray(array $data): StickerObject
+    {
+        if (! in_array($data['type'], $this->allowedTypes, true)) {
+            throw new \InvalidArgumentException($data['type'] . ' is an invalid type of Sticker');
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value
+     */
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+
+    public function toArray(): array
+    {
+        return [$this->getType() => $this->getValue()];
+    }
+}

--- a/src/Messages/Channel/WhatsApp/WhatsAppSticker.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppSticker.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Vonage\Messages\Channel\WhatsApp;
+
+use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\Channel\WhatsApp\MessageObjects\StickerObject;
+
+class WhatsAppSticker extends BaseMessage
+{
+    protected string $subType = BaseMessage::MESSAGES_SUBTYPE_STICKER;
+    protected string $channel = 'whatsapp';
+
+    public function __construct(
+        string $to,
+        string $from,
+        protected StickerObject $sticker
+    ) {
+        $this->to = $to;
+        $this->from = $from;
+    }
+
+    public function getSticker(): StickerObject
+    {
+        return $this->sticker;
+    }
+
+    public function setSticker(StickerObject $sticker): static
+    {
+        $this->sticker = $sticker;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        $returnArray = $this->getBaseMessageUniversalOutputArray();
+        $returnArray['sticker'] = $this->getSticker()->toArray();
+
+        return $returnArray;
+    }
+}

--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -19,6 +19,7 @@ use Vonage\Client\APIResource;
 use Vonage\Messages\Channel\BaseMessage;
 use Vonage\Messages\Channel\Viber\MessageObjects\ViberActionObject;
 use Vonage\Messages\Channel\Viber\ViberFile;
+use Vonage\Messages\Channel\Viber\ViberVideo;
 use Vonage\Messages\Channel\WhatsApp\MessageObjects\StickerObject;
 use Vonage\Messages\Channel\WhatsApp\WhatsAppSticker;
 use Vonage\Messages\ExceptionErrorHandler;
@@ -833,6 +834,47 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('file', $payload['file']->toArray(), $request);
             $this->assertRequestJsonBodyContains('channel', 'viber_service', $request);
             $this->assertRequestJsonBodyContains('message_type', 'file', $request);
+
+            $this->assertEquals('POST', $request->getMethod());
+
+            return true;
+        }))->willReturn($this->getResponse('sms-success', 202));
+
+        $result = $this->messageClient->send($message);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('message_uuid', $result);
+    }
+
+    public function testCanSendViberVideo(): void
+    {
+        $videoObject = new VideoObject(
+            'https://file-examples.com/wp-content/uploads/2017/04/file_example_MP4_480_1_5MG.mp4',
+            'some video'
+        );
+
+        $payload = [
+            'to' => '447700900000',
+            'from' => '16105551212',
+            'video' => $videoObject,
+            'thumb' => 'https://file-examples.com/wp-content/uploads/2017/04/preview.jpg'
+        ];
+
+        $message = new ViberVideo(
+            $payload['to'],
+            $payload['from'],
+            $payload['thumb'],
+            $payload['video']
+        );
+
+        $videoMatch = $videoObject->toArray();
+        $videoMatch['thumb_url'] = $payload['thumb'];
+
+        $this->vonageClient->send(Argument::that(function (Request $request) use ($payload, $videoMatch) {
+            $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
+            $this->assertRequestJsonBodyContains('from', $payload['from'], $request);
+            $this->assertRequestJsonBodyContains('video', $videoMatch, $request);
+            $this->assertRequestJsonBodyContains('channel', 'viber_service', $request);
+            $this->assertRequestJsonBodyContains('message_type', 'video', $request);
 
             $this->assertEquals('POST', $request->getMethod());
 


### PR DESCRIPTION
## Description
WhatsApp Stickers are now available. To create one, you create a new `StickerObject` and pass it into a `WhatsAppSticker` message.

Viber now also has the `action` CTA which you can pass into a `ViberText` or `ViberImage` with `ViberActionObject`
You can also now send `ViberFile` and `ViberVideo`

## Motivation and Context
Evolution of Vonage APIs

## How Has This Been Tested?
Added test for the new WhatsAppSticker object.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
