### PR TITLE
Fix TokenBodyHandler and add it to Verify v1

### DIFF
--- a/src/Client/APIResource.php
+++ b/src/Client/APIResource.php
@@ -112,11 +112,12 @@ class APIResource implements ClientAwareInterface
             $headers
         );
 
+        $request->getBody()->write(json_encode($body));
+
         if ($this->getAuthHandler()) {
             $request = $this->addAuth($request);
         }
 
-        $request->getBody()->write(json_encode($body));
         $this->lastRequest = $request;
 
         $response = $this->getClient()->send($request);

--- a/src/Verify/ClientFactory.php
+++ b/src/Verify/ClientFactory.php
@@ -15,6 +15,7 @@ use Psr\Container\ContainerInterface;
 use Vonage\Client\APIResource;
 use Vonage\Client\Credentials\Handler\BasicHandler;
 use Vonage\Client\Credentials\Handler\KeypairHandler;
+use Vonage\Client\Credentials\Handler\TokenBodyHandler;
 
 class ClientFactory
 {
@@ -27,7 +28,7 @@ class ClientFactory
             ->setIsHAL(false)
             ->setBaseUri('/verify')
             ->setErrorsOn200(true)
-            ->setAuthHandler(new BasicHandler())
+            ->setAuthHandler(new TokenBodyHandler())
             ->setExceptionErrorHandler(new ExceptionErrorHandler());
 
         return new Client($api);


### PR DESCRIPTION
This PR fixes the `TokenBodyHandler`

## Description
The TokenBodyHandler never worked, because it would try and extract the existing body and merge it with credentials and write back. 

Due to the ApiResource not writing the body until after Auth has been handled, it's been moved to fix it.

## Motivation and Context
Verify v1 is not usable right now without this fix.

## How Has This Been Tested?
As with other PRs recently, this one now checks that the auth is being handled in the request properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
