### PR TITLE
Fix purchase number deprecation trigger_error

### DIFF
--- a/src/Numbers/Client.php
+++ b/src/Numbers/Client.php
@@ -225,14 +225,13 @@ class Client implements APIClient
                     "You must supply a country in addition to a number to purchase a number"
                 );
             }
-
+            $number = new Number($number, $country);
+        } else {
             trigger_error(
                 'Passing a Number object to Vonage\Number\Client::purchase() is being deprecated, ' .
                 'please pass a string MSISDN instead',
                 E_USER_DEPRECATED
             );
-
-            $number = new Number($number, $country);
         }
 
         $body = [

--- a/test/Numbers/ClientTest.php
+++ b/test/Numbers/ClientTest.php
@@ -426,11 +426,10 @@ class ClientTest extends VonageTestCase
             return true;
         }))->willReturn($this->getResponse('post'));
 
+        $this->expectException(\PHPUnit\Framework\Error\Deprecated::class);
+        $this->expectExceptionMessage('Passing a Number object to Vonage\Number\Client::purchase() is being deprecated, please pass a string MSISDN instead');
         $number = new Number('1415550100', 'US');
         $this->numberClient->purchase($number);
-
-        // There's nothing to assert here as we don't do anything with the response.
-        // If there's no exception thrown, everything is fine!
     }
 
     /**


### PR DESCRIPTION
The error is currently triggered if you pass a string, but warns you to pass a string.

Either the error is incorrect, or the error needs moving to only trigger when passing a Number object

## Description
I have moved the trigger_error to happen only when a Number object is passed in

## Motivation and Context
The error currently triggers if you pass a string which is wrong

## How Has This Been Tested?
With deprecations turned on in php.ini

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
