### PR TITLE
Fix `Verify2` bug that prevents verifications from being sent

### DIFF
--- a/src/Verify2/ClientFactory.php
+++ b/src/Verify2/ClientFactory.php
@@ -14,7 +14,7 @@ class ClientFactory
         $api = $container->make(APIResource::class);
         $api->setIsHAL(false)
             ->setErrorsOn200(false)
-            ->setAuthHandler([new BasicHandler(), new KeypairHandler()])
+            ->setAuthHandler([new KeypairHandler(), new BasicHandler()])
             ->setBaseUrl('https://api.nexmo.com/v2/verify/');
 
         return new Client($api);

--- a/src/Verify2/ClientFactory.php
+++ b/src/Verify2/ClientFactory.php
@@ -14,7 +14,6 @@ class ClientFactory
         $api = $container->make(APIResource::class);
         $api->setIsHAL(false)
             ->setErrorsOn200(false)
-            ->setClient($this->vonageClient->reveal())
             ->setAuthHandler([new BasicHandler(), new KeypairHandler()])
             ->setBaseUrl('https://api.nexmo.com/v2/verify/');
 

--- a/src/Verify2/ClientFactory.php
+++ b/src/Verify2/ClientFactory.php
@@ -2,13 +2,14 @@
 
 namespace Vonage\Verify2;
 
+use Psr\Container\ContainerInterface;
 use Vonage\Client\APIResource;
 use Vonage\Client\Credentials\Handler\BasicHandler;
 use Vonage\Client\Credentials\Handler\KeypairHandler;
 
 class ClientFactory
 {
-    public function __invoke(): Client
+    public function __invoke(ContainerInterface $container): Client
     {
         $api = $container->make(APIResource::class);
         $api->setIsHAL(false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I'm currently working on writing a blog post about how to add 2FA to Laravel Apps using the Verify 2 API. I'm building out a demo app to show how it could all work.

It seems that I get an exception is thrown because `$container` isn't set in the `ClientFactory` when I try to run the following code:

```php
use App\Models\User;
use Vonage\Client;
use Vonage\Verify2\Request\SMSRequest;

final class TwoFactorAuthService
{
    public function sendVerification(User $user): string
    {
        $smsRequest = (new SMSRequest(
            to: 'PHONE NUMBER HERE',
            brand: 'Vonage Verify Tutorial',
        ))->setLength(6);

        $result = app(Client::class)
            ->verify2()
            ->startVerification($smsRequest);
    }
}
```

From looking at the other client factory classes, I've made the assumption that the argument needed adding to the `__invoke` method, so I added that in.

After I added this, it seemed to stop that exception from being thrown, but I then ran into another issue. It looks like we're trying to access `$this->vonageClient` in the `setClient` method but it doesn't look like that can be accessed because it's not a property anywhere (from what I can see).

I made a guess and removed that line (to match the other client factory classes) to see if it would fix the error.

I _think_ it might have fixed the error but I'm not entirely sure. It looks like doing this allowed the request to be made to the API, but I then got the following error message:

```text
Invalid params: The value of one or more parameters is invalid. See https://www.nexmo.com/messages/Errors#InvalidParams for more information
```

I'm not sure if this error message is a legitimate error message being returned from the API, or has been caused by me making any changes to the client factory.

I also noticed that when I went to the URL specified in that error message that I was redirected to https://www.vonage.com/communications-apis/?icid=nexmo_rd#InvalidParams so I wasn't able to figure out anything else about the error.

So this PR _might_ solve an issue, but I'm not 100% sure because this is the first time I've tinkered with the Verify2 API before 🙂

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm writing a blog post that makes use of the Verify 2 feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've only manually tested this, but I'm happy to add automated tests if needed.

## Example Output or Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
