### PR TITLE
Remove vonage/nexmo-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "lcobucci/jwt": "^3.4|^4.0",
     "psr/container": "^1.0 | ^2.0",
     "psr/http-client-implementation": "^1.0",
-    "vonage/nexmo-bridge": "^0.1.0",
     "psr/log": "^1.1|^2.0|^3.0"
   },
   "require-dev": {  


### PR DESCRIPTION
Fix issue https://github.com/Vonage/vonage-php-sdk-core/issues/398

<!--- Provide a general summary of your changes in the Title above -->

## Description
vonage/nexmo-bridge must be removed

## Motivation and Context
It has been around 3 years since it was introduced 

## How Has This Been Tested?
I believe all of developers has changed their namespace in their code, and if they have not, they can still install this package to keep backward compatibility 

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
