### PR TITLE
Feature/verify v2 byop

### DIFF
--- a/src/Verify2/Request/BaseVerifyRequest.php
+++ b/src/Verify2/Request/BaseVerifyRequest.php
@@ -24,6 +24,8 @@ abstract class BaseVerifyRequest implements RequestInterface
 
     protected array $workflows = [];
 
+    protected ?string $code = null;
+
     public function getLocale(): ?VerificationLocale
     {
         return $this->locale;
@@ -53,6 +55,18 @@ abstract class BaseVerifyRequest implements RequestInterface
         }
 
         $this->timeout = $timeout;
+
+        return $this;
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    public function setCode(string $code): static
+    {
+        $this->code = $code;
 
         return $this;
     }
@@ -106,7 +120,7 @@ abstract class BaseVerifyRequest implements RequestInterface
 
     public function getWorkflows(): array
     {
-        return array_map(static function($workflow) {
+        return array_map(static function ($workflow) {
             return $workflow->toArray();
         }, $this->workflows);
     }
@@ -130,6 +144,10 @@ abstract class BaseVerifyRequest implements RequestInterface
 
         if ($this->getClientRef()) {
             $returnArray['client_ref'] = $this->getClientRef();
+        }
+
+        if ($this->getCode()) {
+            $returnArray['code'] = $this->getCode();
         }
 
         return $returnArray;

--- a/src/Verify2/Request/EmailRequest.php
+++ b/src/Verify2/Request/EmailRequest.php
@@ -13,12 +13,18 @@ class EmailRequest extends BaseVerifyRequest
         protected string $from,
         protected ?string $clientRef = null,
         protected ?VerificationLocale $locale = null,
+        protected ?string $code = null
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }
 
         $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_EMAIL, $to, $from);
+
+        if ($this->code) {
+            $workflow->setCode($this->code);
+        }
+
         $this->addWorkflow($workflow);
     }
 

--- a/src/Verify2/Request/EmailRequest.php
+++ b/src/Verify2/Request/EmailRequest.php
@@ -11,19 +11,17 @@ class EmailRequest extends BaseVerifyRequest
         protected string $to,
         protected string $brand,
         protected string $from,
-        protected ?string $clientRef = null,
         protected ?VerificationLocale $locale = null,
-        protected ?string $code = null
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }
 
-        $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_EMAIL, $to, $from);
-
         if ($this->code) {
-            $workflow->setCode($this->code);
+            $this->setCode($this->code);
         }
+
+        $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_EMAIL, $to, $from);
 
         $this->addWorkflow($workflow);
     }

--- a/src/Verify2/Request/RequestInterface.php
+++ b/src/Verify2/Request/RequestInterface.php
@@ -20,4 +20,6 @@ interface RequestInterface
     public function getBrand(): string;
     public function getWorkflows(): array;
     public function getBaseVerifyUniversalOutputArray(): array;
+    public function setCode(string $code): static;
+    public function getCode(): ?string;
 }

--- a/src/Verify2/Request/SMSRequest.php
+++ b/src/Verify2/Request/SMSRequest.php
@@ -11,13 +11,19 @@ class SMSRequest extends BaseVerifyRequest
         protected string $to,
         protected string $brand,
         protected ?string $clientRef = null,
-        protected ?VerificationLocale $locale = null
+        protected ?VerificationLocale $locale = null,
+        protected ?string $code = null
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }
 
         $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_SMS, $to);
+
+        if ($this->code) {
+            $workflow->setCode($this->code);
+        }
+
         $this->addWorkflow($workflow);
     }
 

--- a/src/Verify2/Request/SMSRequest.php
+++ b/src/Verify2/Request/SMSRequest.php
@@ -10,19 +10,13 @@ class SMSRequest extends BaseVerifyRequest
     public function __construct(
         protected string $to,
         protected string $brand,
-        protected ?string $clientRef = null,
         protected ?VerificationLocale $locale = null,
-        protected ?string $code = null
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }
 
         $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_SMS, $to);
-
-        if ($this->code) {
-            $workflow->setCode($this->code);
-        }
 
         $this->addWorkflow($workflow);
     }

--- a/src/Verify2/Request/VoiceRequest.php
+++ b/src/Verify2/Request/VoiceRequest.php
@@ -11,13 +11,19 @@ class VoiceRequest extends BaseVerifyRequest
         protected string $to,
         protected string $brand,
         protected ?string $clientRef,
-        protected ?VerificationLocale $locale = null
+        protected ?VerificationLocale $locale = null,
+        protected ?string $code = null
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }
 
         $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_VOICE, $to);
+
+        if ($this->code) {
+            $workflow->setCode($this->code);
+        }
+
         $this->addWorkflow($workflow);
     }
 

--- a/src/Verify2/Request/VoiceRequest.php
+++ b/src/Verify2/Request/VoiceRequest.php
@@ -10,9 +10,7 @@ class VoiceRequest extends BaseVerifyRequest
     public function __construct(
         protected string $to,
         protected string $brand,
-        protected ?string $clientRef,
         protected ?VerificationLocale $locale = null,
-        protected ?string $code = null
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();

--- a/src/Verify2/Request/WhatsAppInteractiveRequest.php
+++ b/src/Verify2/Request/WhatsAppInteractiveRequest.php
@@ -10,7 +10,6 @@ class WhatsAppInteractiveRequest extends BaseVerifyRequest
     public function __construct(
         protected string $to,
         protected string $brand,
-        protected ?string $clientRef,
         protected ?VerificationLocale $locale = null
     ) {
         if (!$this->locale) {

--- a/src/Verify2/Request/WhatsAppRequest.php
+++ b/src/Verify2/Request/WhatsAppRequest.php
@@ -12,13 +12,19 @@ class WhatsAppRequest extends BaseVerifyRequest
         protected string $brand,
         protected ?string $from = null,
         protected ?string $clientRef = null,
-        protected ?VerificationLocale $locale = null
+        protected ?VerificationLocale $locale = null,
+        protected ?string $code = null
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }
 
         $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_WHATSAPP, $to);
+
+        if ($this->code) {
+            $workflow->setCode($this->code);
+        }
+
         $this->addWorkflow($workflow);
     }
 

--- a/src/Verify2/Request/WhatsAppRequest.php
+++ b/src/Verify2/Request/WhatsAppRequest.php
@@ -11,19 +11,13 @@ class WhatsAppRequest extends BaseVerifyRequest
         protected string $to,
         protected string $brand,
         protected ?string $from = null,
-        protected ?string $clientRef = null,
         protected ?VerificationLocale $locale = null,
-        protected ?string $code = null
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }
 
         $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_WHATSAPP, $to);
-
-        if ($this->code) {
-            $workflow->setCode($this->code);
-        }
 
         $this->addWorkflow($workflow);
     }

--- a/src/Verify2/VerifyObjects/VerificationWorkflow.php
+++ b/src/Verify2/VerifyObjects/VerificationWorkflow.php
@@ -22,11 +22,36 @@ class VerificationWorkflow implements ArrayHydrateInterface
         self::WORKFLOW_SILENT_AUTH
     ];
 
-    public function __construct(protected string $channel, protected string $to, protected string $from = '')
-    {
+    protected ?string $code = null;
+
+    public function __construct(
+        protected string $channel,
+        protected string $to,
+        protected string $from = ''
+    ) {
         if (! in_array($channel, $this->allowedWorkflows, true)) {
             throw new \InvalidArgumentException($this->channel . ' is not a valid workflow');
         }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string|null $code
+     *
+     * @return VerificationWorkflow
+     */
+    public function setCode(?string $code): VerificationWorkflow
+    {
+        $this->code = $code;
+
+        return $this;
     }
 
     public function getChannel(): string
@@ -88,7 +113,10 @@ class VerificationWorkflow implements ArrayHydrateInterface
             $returnArray['from'] = $this->getFrom();
         }
 
-        return $returnArray;
+        if ($this->getCode()) {
+            $returnArray['code'] = $this->getCode();
+        }
 
+        return $returnArray;
     }
 }

--- a/src/Verify2/VerifyObjects/VerificationWorkflow.php
+++ b/src/Verify2/VerifyObjects/VerificationWorkflow.php
@@ -22,8 +22,6 @@ class VerificationWorkflow implements ArrayHydrateInterface
         self::WORKFLOW_SILENT_AUTH
     ];
 
-    protected ?string $code = null;
-
     public function __construct(
         protected string $channel,
         protected string $to,
@@ -32,26 +30,6 @@ class VerificationWorkflow implements ArrayHydrateInterface
         if (! in_array($channel, $this->allowedWorkflows, true)) {
             throw new \InvalidArgumentException($this->channel . ' is not a valid workflow');
         }
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getCode(): ?string
-    {
-        return $this->code;
-    }
-
-    /**
-     * @param string|null $code
-     *
-     * @return VerificationWorkflow
-     */
-    public function setCode(?string $code): VerificationWorkflow
-    {
-        $this->code = $code;
-
-        return $this;
     }
 
     public function getChannel(): string
@@ -111,10 +89,6 @@ class VerificationWorkflow implements ArrayHydrateInterface
 
         if (!empty($this->getFrom())) {
             $returnArray['from'] = $this->getFrom();
-        }
-
-        if ($this->getCode()) {
-            $returnArray['code'] = $this->getCode();
         }
 
         return $returnArray;

--- a/test/Verify2/ClientTest.php
+++ b/test/Verify2/ClientTest.php
@@ -332,6 +332,96 @@ class ClientTest extends VonageTestCase
         $this->assertArrayHasKey('request_id', $result);
     }
 
+    public function testSMSCanRenderOptionalCode(): void
+    {
+        $payload = [
+            'to' => '07785648870',
+            'brand' => 'my-brand',
+        ];
+
+        $smsRequest = new SMSRequest($payload['to'], $payload['brand'], null, null, '123456789');
+
+        $this->vonageClient->send(Argument::that(function (Request $request) {
+            $this->assertRequestJsonBodyContains('code', '123456789', $request, true);
+
+            return true;
+        }))->willReturn($this->getResponse('verify-request-success', 202));
+
+        $result = $this->verify2Client->startVerification($smsRequest);
+    }
+
+    public function testSMSWillRenderOptionalCodep(): void
+    {
+        $payload = [
+            'to' => '07785648870',
+            'brand' => 'my-brand',
+        ];
+
+        $smsRequest = new SMSRequest($payload['to'], $payload['brand'], null, null, '123456789');
+
+        $this->vonageClient->send(Argument::that(function (Request $request) {
+            $this->assertRequestJsonBodyContains('code', '123456789', $request, true);
+
+            return true;
+        }))->willReturn($this->getResponse('verify-request-success', 202));
+
+        $this->verify2Client->startVerification($smsRequest);
+    }
+
+    public function testVoiceWillRenderOptionalCode(): void
+    {
+        $payload = [
+            'to' => '07785648870',
+            'brand' => 'my-brand',
+        ];
+
+        $voiceRequest = new VoiceRequest($payload['to'], $payload['brand'], null, null, '123456789');
+
+        $this->vonageClient->send(Argument::that(function (Request $request) {
+            $this->assertRequestJsonBodyContains('code', '123456789', $request, true);
+
+            return true;
+        }))->willReturn($this->getResponse('verify-request-success', 202));
+
+        $this->verify2Client->startVerification($voiceRequest);
+    }
+
+    public function testWhatsAppWillRenderOptionalCode(): void
+    {
+        $payload = [
+            'to' => '07785648870',
+            'brand' => 'my-brand',
+        ];
+
+        $voiceRequest = new WhatsAppRequest($payload['to'], $payload['brand'], null, null, null, '123456789');
+
+        $this->vonageClient->send(Argument::that(function (Request $request) {
+            $this->assertRequestJsonBodyContains('code', '123456789', $request, true);
+
+            return true;
+        }))->willReturn($this->getResponse('verify-request-success', 202));
+
+        $this->verify2Client->startVerification($voiceRequest);
+    }
+
+    public function testEmailWillRenderOptionalCode(): void
+    {
+        $payload = [
+            'to' => 'jim@jim.com',
+            'brand' => 'my-brand',
+        ];
+
+        $voiceRequest = new EmailRequest($payload['to'], $payload['brand'], 'test@test.com', null, null, '123456789');
+
+        $this->vonageClient->send(Argument::that(function (Request $request) {
+            $this->assertRequestJsonBodyContains('code', '123456789', $request, true);
+
+            return true;
+        }))->willReturn($this->getResponse('verify-request-success', 202));
+
+        $this->verify2Client->startVerification($voiceRequest);
+    }
+
     public function testCanHandleMultipleWorkflows(): void
     {
         $payload = [

--- a/test/Verify2/ClientTest.php
+++ b/test/Verify2/ClientTest.php
@@ -64,7 +64,8 @@ class ClientTest extends VonageTestCase
             'brand' => 'my-brand',
         ];
 
-        $smsVerification = new SMSRequest($payload['to'], $payload['brand'], $payload['client_ref']);
+        $smsVerification = new SMSRequest($payload['to'], $payload['brand']);
+        $smsVerification->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) {
             $this->assertEquals(
@@ -85,7 +86,8 @@ class ClientTest extends VonageTestCase
             'brand' => 'my-brand',
         ];
 
-        $smsVerification = new SMSRequest($payload['to'], $payload['brand'], $payload['client_ref']);
+        $smsVerification = new SMSRequest($payload['to'], $payload['brand']);
+        $smsVerification->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $uri = $request->getUri();
@@ -131,7 +133,8 @@ class ClientTest extends VonageTestCase
             'locale' => $verificationLocale,
         ];
 
-        $smsVerification = new SMSRequest($payload['to'], $payload['brand'], $payload['client_ref'], $payload['locale']);
+        $smsVerification = new SMSRequest($payload['to'], $payload['brand'], $payload['locale']);
+        $smsVerification->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertEquals(
@@ -167,7 +170,8 @@ class ClientTest extends VonageTestCase
             'timeout' => $timeout
         ];
 
-        $smsVerification = new SMSRequest($payload['to'], $payload['brand'], $payload['client_ref']);
+        $smsVerification = new SMSRequest($payload['to'], $payload['brand']);
+        $smsVerification->setClientRef($payload['client_ref']);
         $smsVerification->setTimeout($timeout);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
@@ -203,7 +207,8 @@ class ClientTest extends VonageTestCase
             'length' => $length
         ];
 
-        $smsVerification = new SMSRequest($payload['to'], $payload['brand'], $payload['client_ref']);
+        $smsVerification = new SMSRequest($payload['to'], $payload['brand']);
+        $smsVerification->setClientRef($payload['client_ref']);
         $smsVerification->setLength($payload['length']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
@@ -225,7 +230,8 @@ class ClientTest extends VonageTestCase
             'brand' => 'my-brand',
         ];
 
-        $whatsAppVerification = new WhatsAppRequest($payload['to'], $payload['brand'],null, $payload['client_ref']);
+        $whatsAppVerification = new WhatsAppRequest($payload['to'], $payload['brand']);
+        $whatsAppVerification->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('locale', 'en-us', $request);
@@ -254,7 +260,8 @@ class ClientTest extends VonageTestCase
             'brand' => 'my-brand',
         ];
 
-        $whatsAppInteractiveRequest = new WhatsAppInteractiveRequest($payload['to'], $payload['brand'], $payload['client_ref']);
+        $whatsAppInteractiveRequest = new WhatsAppInteractiveRequest($payload['to'], $payload['brand']);
+        $whatsAppInteractiveRequest->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('locale', 'en-us', $request);
@@ -282,7 +289,8 @@ class ClientTest extends VonageTestCase
             'brand' => 'my-brand',
         ];
 
-        $voiceRequest = new VoiceRequest($payload['to'], $payload['brand'], $payload['client_ref']);
+        $voiceRequest = new VoiceRequest($payload['to'], $payload['brand']);
+        $voiceRequest->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('locale', 'en-us', $request);
@@ -311,7 +319,8 @@ class ClientTest extends VonageTestCase
             'brand' => 'my-brand',
         ];
 
-        $emailRequest = new EmailRequest($payload['to'], $payload['brand'], $payload['from'], $payload['client_ref']);
+        $emailRequest = new EmailRequest($payload['to'], $payload['brand'], $payload['from']);
+        $emailRequest->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('locale', 'en-us', $request);
@@ -332,14 +341,15 @@ class ClientTest extends VonageTestCase
         $this->assertArrayHasKey('request_id', $result);
     }
 
-    public function testSMSCanRenderOptionalCode(): void
+    public function testCanRenderOptionalCode(): void
     {
         $payload = [
             'to' => '07785648870',
             'brand' => 'my-brand',
         ];
 
-        $smsRequest = new SMSRequest($payload['to'], $payload['brand'], null, null, '123456789');
+        $smsRequest = new SMSRequest($payload['to'], $payload['brand']);
+        $smsRequest->setCode('123456789');
 
         $this->vonageClient->send(Argument::that(function (Request $request) {
             $this->assertRequestJsonBodyContains('code', '123456789', $request, true);
@@ -350,78 +360,6 @@ class ClientTest extends VonageTestCase
         $result = $this->verify2Client->startVerification($smsRequest);
     }
 
-    public function testSMSWillRenderOptionalCodep(): void
-    {
-        $payload = [
-            'to' => '07785648870',
-            'brand' => 'my-brand',
-        ];
-
-        $smsRequest = new SMSRequest($payload['to'], $payload['brand'], null, null, '123456789');
-
-        $this->vonageClient->send(Argument::that(function (Request $request) {
-            $this->assertRequestJsonBodyContains('code', '123456789', $request, true);
-
-            return true;
-        }))->willReturn($this->getResponse('verify-request-success', 202));
-
-        $this->verify2Client->startVerification($smsRequest);
-    }
-
-    public function testVoiceWillRenderOptionalCode(): void
-    {
-        $payload = [
-            'to' => '07785648870',
-            'brand' => 'my-brand',
-        ];
-
-        $voiceRequest = new VoiceRequest($payload['to'], $payload['brand'], null, null, '123456789');
-
-        $this->vonageClient->send(Argument::that(function (Request $request) {
-            $this->assertRequestJsonBodyContains('code', '123456789', $request, true);
-
-            return true;
-        }))->willReturn($this->getResponse('verify-request-success', 202));
-
-        $this->verify2Client->startVerification($voiceRequest);
-    }
-
-    public function testWhatsAppWillRenderOptionalCode(): void
-    {
-        $payload = [
-            'to' => '07785648870',
-            'brand' => 'my-brand',
-        ];
-
-        $voiceRequest = new WhatsAppRequest($payload['to'], $payload['brand'], null, null, null, '123456789');
-
-        $this->vonageClient->send(Argument::that(function (Request $request) {
-            $this->assertRequestJsonBodyContains('code', '123456789', $request, true);
-
-            return true;
-        }))->willReturn($this->getResponse('verify-request-success', 202));
-
-        $this->verify2Client->startVerification($voiceRequest);
-    }
-
-    public function testEmailWillRenderOptionalCode(): void
-    {
-        $payload = [
-            'to' => 'jim@jim.com',
-            'brand' => 'my-brand',
-        ];
-
-        $voiceRequest = new EmailRequest($payload['to'], $payload['brand'], 'test@test.com', null, null, '123456789');
-
-        $this->vonageClient->send(Argument::that(function (Request $request) {
-            $this->assertRequestJsonBodyContains('code', '123456789', $request, true);
-
-            return true;
-        }))->willReturn($this->getResponse('verify-request-success', 202));
-
-        $this->verify2Client->startVerification($voiceRequest);
-    }
-
     public function testCanHandleMultipleWorkflows(): void
     {
         $payload = [
@@ -430,7 +368,8 @@ class ClientTest extends VonageTestCase
             'brand' => 'my-brand',
         ];
 
-        $smsVerification = new SMSRequest($payload['to'], $payload['brand'], $payload['client_ref']);
+        $smsVerification = new SMSRequest($payload['to'], $payload['brand']);
+        $smsVerification->setClientRef($payload['client_ref']);
         $voiceWorkflow = new VerificationWorkflow('voice', '07785254785');
         $smsVerification->addWorkflow($voiceWorkflow);
 
@@ -479,7 +418,8 @@ class ClientTest extends VonageTestCase
             'brand' => 'my-brand',
         ];
 
-        $smsVerification = new SMSRequest($payload['to'], $payload['brand'], $payload['client_ref']);
+        $smsVerification = new SMSRequest($payload['to'], $payload['brand']);
+        $smsVerification->setClientRef( $payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) {
             $this->assertEquals('POST', $request->getMethod());
@@ -508,7 +448,8 @@ class ClientTest extends VonageTestCase
             'brand' => '',
         ];
 
-        $voiceRequest = new VoiceRequest($payload['to'], $payload['brand'], $payload['client_ref']);
+        $voiceRequest = new VoiceRequest($payload['to'], $payload['brand']);
+        $voiceRequest->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) {
             $this->assertEquals('POST', $request->getMethod());
@@ -529,7 +470,8 @@ class ClientTest extends VonageTestCase
             'brand' => 'my-brand',
         ];
 
-        $voiceRequest = new VoiceRequest($payload['to'], $payload['brand'], $payload['client_ref']);
+        $voiceRequest = new VoiceRequest($payload['to'], $payload['brand']);
+        $voiceRequest->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) {
             $this->assertEquals('POST', $request->getMethod());


### PR DESCRIPTION
This adds the ability for the developer to set your own PIN in Verify V2

## Description
You can now call `request->setCode(CODE)` on a Verify request to use your own generated PIN.

## Motivation and Context
New API features

## How Has This Been Tested?
Tests added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
