### PR TITLE
Fix small cedilla test + encoding

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,9 @@
     <testsuite name="verify2">
       <directory>test/Verify2</directory>
     </testsuite>
+    <testsuite name="messages">
+      <directory>test/Messages</directory>
+    </testsuite>
   </testsuites>
   <php>
         <ini name='error_reporting' value='E_ALL' />

--- a/src/SMS/Message/SMS.php
+++ b/src/SMS/Message/SMS.php
@@ -32,7 +32,7 @@ class SMS extends OutboundMessage
 
     public static function isGsm7(string $message): bool
     {
-        $fullPattern = "/\A[" . preg_quote(self::GSM_7_CHARSET, '/') . "]*\z/";
+        $fullPattern = "/\A[" . preg_quote(self::GSM_7_CHARSET, '/') . "]*\z/u";
         return (bool)preg_match($fullPattern, $message);
     }
 

--- a/test/SMS/Message/SMSTest.php
+++ b/test/SMS/Message/SMSTest.php
@@ -185,7 +185,7 @@ class SMSTest extends VonageTestCase
             ['This is a text with some tasty characters: [test]', true],
             ['This is also a GSM7 text', true],
             ['This is a Çotcha', true],
-            ['This is also a çotcha', true],
+            ['This is also a çotcha', false],
             ['日本語でボナージュ', false],
         ];
     }


### PR DESCRIPTION
This PR fixes the regex and test for the small cedilla to not be counted as GSM-7

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
