### PR TITLE
Added fraud check

### DIFF
--- a/src/Verify2/Request/BaseVerifyRequest.php
+++ b/src/Verify2/Request/BaseVerifyRequest.php
@@ -16,6 +16,8 @@ abstract class BaseVerifyRequest implements RequestInterface
 
     protected int $timeout = 300;
 
+    protected bool $fraudCheck = true;
+
     protected ?string $clientRef = null;
 
     protected int $length = 4;
@@ -132,9 +134,22 @@ abstract class BaseVerifyRequest implements RequestInterface
         return $this;
     }
 
+    public function getFraudCheck(): bool
+    {
+        return $this->fraudCheck;
+    }
+
+    public function setFraudCheck(bool $fraudCheck): BaseVerifyRequest
+    {
+        $this->fraudCheck = $fraudCheck;
+
+        return $this;
+    }
+
     public function getBaseVerifyUniversalOutputArray(): array
     {
         $returnArray = [
+            'fraud_check' => $this->getFraudCheck(),
             'locale' => $this->getLocale()->getCode(),
             'channel_timeout' => $this->getTimeout(),
             'code_length' => $this->getLength(),


### PR DESCRIPTION
This PR adds `fraud_check` to the outgoing Verify v2 request.

## Description
`fraud_check` will default to `true`, but the developer does have the option to switch it off in any new verification request using the base method `setFraudCheck(false)`

## How Has This Been Tested?
Additional test to check the outgoing request is correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
