### PR TITLE
Redefine fraud_check rendering

### DIFF
--- a/src/Verify2/Request/BaseVerifyRequest.php
+++ b/src/Verify2/Request/BaseVerifyRequest.php
@@ -16,7 +16,7 @@ abstract class BaseVerifyRequest implements RequestInterface
 
     protected int $timeout = 300;
 
-    protected bool $fraudCheck = true;
+    protected ?bool $fraudCheck = null;
 
     protected ?string $clientRef = null;
 
@@ -134,9 +134,9 @@ abstract class BaseVerifyRequest implements RequestInterface
         return $this;
     }
 
-    public function getFraudCheck(): bool
+    public function getFraudCheck(): ?bool
     {
-        return $this->fraudCheck;
+        return $this->fraudCheck ?? null;
     }
 
     public function setFraudCheck(bool $fraudCheck): BaseVerifyRequest
@@ -149,13 +149,16 @@ abstract class BaseVerifyRequest implements RequestInterface
     public function getBaseVerifyUniversalOutputArray(): array
     {
         $returnArray = [
-            'fraud_check' => $this->getFraudCheck(),
             'locale' => $this->getLocale()->getCode(),
             'channel_timeout' => $this->getTimeout(),
             'code_length' => $this->getLength(),
             'brand' => $this->getBrand(),
             'workflow' => $this->getWorkflows()
         ];
+
+        if ($this->getFraudCheck() === false) {
+            $returnArray['fraud_check'] = $this->getFraudCheck();
+        }
 
         if ($this->getClientRef()) {
             $returnArray['client_ref'] = $this->getClientRef();

--- a/test/Verify2/ClientTest.php
+++ b/test/Verify2/ClientTest.php
@@ -98,7 +98,7 @@ class ClientTest extends VonageTestCase
             );
 
             $this->assertRequestJsonBodyContains('locale', 'en-us', $request);
-            $this->assertRequestJsonBodyContains('fraud_check', true, $request);
+            $this->assertRequestJsonBodyMissing('fraud_check', $request);
             $this->assertRequestJsonBodyContains('channel_timeout', 300, $request);
             $this->assertRequestJsonBodyContains('client_ref', $payload['client_ref'], $request);
             $this->assertRequestJsonBodyContains('code_length', 4, $request);
@@ -120,14 +120,13 @@ class ClientTest extends VonageTestCase
     {
         $payload = [
             'to' => '07785254785',
-            'client_ref' => 'my-verification',
             'brand' => 'my-brand',
         ];
 
         $smsVerification = new SMSRequest($payload['to'], $payload['brand']);
         $smsVerification->setFraudCheck(false);
 
-        $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
+        $this->vonageClient->send(Argument::that(function (Request $request) {
             $this->assertRequestJsonBodyContains('fraud_check', false, $request);
 
             return true;


### PR DESCRIPTION
Rendering `fraud_check` on a request will 403 if the Network Unblock API has not been enabled on an account. As this defaults to `true`, the only condition that should render in the payload for a request is if the developer has *explicitly* told the SDK to render a `false` bypass.