### PR TITLE
Fix getRecording for Voice, URL Override

### DIFF
--- a/src/Client/APIResource.php
+++ b/src/Client/APIResource.php
@@ -188,9 +188,14 @@ class APIResource implements ClientAwareInterface
      * @throws ClientExceptionInterface
      * @throws Exception\Exception
      */
-    public function get($id, array $query = [], array $headers = [], bool $jsonResponse = true)
+    public function get($id, array $query = [], array $headers = [], bool $jsonResponse = true, bool $uriOverride = false)
     {
         $uri = $this->getBaseUrl() . $this->baseUri . '/' . $id;
+
+        // This is a necessary hack if you want to fetch a totally different URL but use Vonage Auth
+        if ($uriOverride) {
+            $uri = $id;
+        }
 
         if (!empty($query)) {
             $uri .= '?' . http_build_query($query);

--- a/src/Voice/Client.php
+++ b/src/Voice/Client.php
@@ -274,6 +274,6 @@ class Client implements APIClient
 
     public function getRecording(string $url): StreamInterface
     {
-        return $this->getAPIResource()->get($url, [], [], false);
+        return $this->getAPIResource()->get($url, [], [], false, true);
     }
 }

--- a/test/Voice/ClientTest.php
+++ b/test/Voice/ClientTest.php
@@ -646,7 +646,7 @@ class ClientTest extends VonageTestCase
     public function testCanDownloadRecording(): void
     {
         $fixturePath = __DIR__ . '/Fixtures/mp3fixture.mp3';
-        $url = 'recordings/mp3fixture.mp3';
+        $url = 'https://api-us.nexmo.com/v1/files/999f999-526d-4013-87fc-c824f7a443b3';
 
         $this->vonageClient->send(Argument::that(function (RequestInterface $request) {
             $this->assertEquals(
@@ -657,7 +657,7 @@ class ClientTest extends VonageTestCase
             $uri = $request->getUri();
             $uriString = $uri->__toString();
             $this->assertEquals(
-                'https://api.nexmo.com/v1/calls/recordings/mp3fixture.mp3',
+                'https://api-us.nexmo.com/v1/files/999f999-526d-4013-87fc-c824f7a443b3',
                 $uriString
             );
             return true;


### PR DESCRIPTION
This contains an important bug fix for Voice

## Description
The original release of `getRecording()` in the Voice client would still contain the baseURL and baseUri inherited from the APIResource configuration.

`getRecording()` needs the edge case ability to take any URL it's given (from the voice webhook containing a download URL) and apply Vonage credentials to it.

## Motivation and Context
The Vonage Helpdesk project has identified this as a major bug. We also want to phase out users using the old base Vonage client `get()` method as Auth is all handled within configurable `APIResource` objects.

## How Has This Been Tested?
Fixed the test, which was one of the primary failures to identify this as it was testing the path stitched together with the baseURL and uri.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
