### PR TITLE
Output typo for backend when using AMD

### DIFF
--- a/src/Voice/VoiceObjects/AdvancedMachineDetection.php
+++ b/src/Voice/VoiceObjects/AdvancedMachineDetection.php
@@ -81,7 +81,7 @@ class AdvancedMachineDetection implements ArrayHydrateInterface
     public function toArray(): array
     {
         return [
-            'behaviour' => $this->behaviour,
+            'behavior' => $this->behaviour,
             'mode' => $this->mode,
             'beep_timeout' => $this->beepTimeout
         ];


### PR DESCRIPTION
This is a small patch PR to change the output of Advanced Machine Detection to the US spelling of behaviour.