### PR TITLE
Meetings API logic changes

### DIFF
--- a/src/Meetings/Client.php
+++ b/src/Meetings/Client.php
@@ -6,8 +6,10 @@ namespace Vonage\Meetings;
 
 use GuzzleHttp\Psr7\MultipartStream;
 use Laminas\Diactoros\Request;
+use Psr\Http\Client\ClientExceptionInterface;
 use Vonage\Client\APIClient;
 use Vonage\Client\APIResource;
+use Vonage\Client\Exception\Exception;
 use Vonage\Client\Exception\NotFound;
 use Vonage\Entity\Filter\KeyValueFilter;
 use Vonage\Entity\Hydrator\ArrayHydrator;
@@ -36,8 +38,29 @@ class Client implements APIClient
         return $room;
     }
 
-    public function createRoom(Room $room): Room
+    /**
+     *
+     * Creates a room. Originally this was a string with the display name
+     * So there is backwards compatibility cases to cover
+     *
+     * @param $room string|Room
+     *
+     * @return Room
+     * @throws ClientExceptionInterface
+     * @throws Exception
+     */
+    public function createRoom(Room|string $room): Room
     {
+        if (is_string($room)) {
+            trigger_error(
+                'Passing a display name string to createRoom is deprecated, please use a Room object',
+                E_USER_DEPRECATED
+            );
+            $roomEntity = new Room();
+            $roomEntity->fromArray(['display_name' => $room]);
+            $room = $roomEntity;
+        }
+
         $this->api->setBaseUri('/rooms');
 
         $response = $this->api->create($room->toArray());

--- a/src/Meetings/Client.php
+++ b/src/Meetings/Client.php
@@ -36,13 +36,11 @@ class Client implements APIClient
         return $room;
     }
 
-    public function createRoom(string $displayName): Room
+    public function createRoom(Room $room): Room
     {
         $this->api->setBaseUri('/rooms');
 
-        $response = $this->api->create([
-            'display_name' => $displayName
-        ]);
+        $response = $this->api->create($room->toArray());
 
         $room = new Room();
         $room->fromArray($response);

--- a/src/Meetings/Room.php
+++ b/src/Meetings/Room.php
@@ -6,20 +6,28 @@ use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 
 class Room implements ArrayHydrateInterface
 {
-    private array $data;
+    protected array $data;
 
-    public function fromArray(array $data): void
+    public function fromArray(array $data): static
     {
+        if (!isset($data['display_name'])) {
+            throw new \InvalidArgumentException('A room object must contain a display_name');
+        }
+
         $this->data = $data;
+
+        return $this;
     }
 
     public function toArray(): array
     {
-        return $this->data;
+        return array_filter($this->data, static function ($value) {
+            return $value !== '';
+        });
     }
 
-    public function __get($name)
+    public function __get($value)
     {
-        return $this->data[$name];
+        return $this->data[$value];
     }
 }

--- a/test/Meetings/Fixtures/Responses/create-long-term-room-success.json
+++ b/test/Meetings/Fixtures/Responses/create-long-term-room-success.json
@@ -1,7 +1,7 @@
 {
   "display_name": "test-room",
   "metadata": "Welcome to my custom room",
-  "type": "instant",
+  "type": "long_term",
   "recording_options": {
     "auto_record": false,
     "record_only_owner": false


### PR DESCRIPTION
The Meetings API Client in the SDK does not currently allow you to create a new long-term room, or give any other optional request parameters.

## Description
For backwards compatibility, you can still pass in a `display_name` for the room into the `createRoom()` method, but you will get a deprecation notice. The user is now expected to create a Room object to send to the class, allowing the user to give the Room object any custom array of properties to render out during the request.

## Motivation and Context
Long term rooms could not be created

## How Has This Been Tested?
Test has been added for creation of a long term room

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
