### PR TITLE
Fix Numbers Flow

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,9 @@
     <testsuite name="voice">
       <directory>test/Voice</directory>
     </testsuite>
+    <testsuite name="numbers">
+      <directory>test/Numbers</directory>
+    </testsuite>
     <testsuite name="messages">
       <directory>test/Messages</directory>
     </testsuite>

--- a/src/Numbers/Client.php
+++ b/src/Numbers/Client.php
@@ -217,14 +217,13 @@ class Client implements APIClient
      */
     public function purchase($number, ?string $country = null): void
     {
-        // We cheat here and fetch a number using the API so that we have the country code which is required
-        // to make a purchase request
-        if (!$number instanceof Number) {
-            if (!$country) {
-                throw new ClientException\Exception(
-                    "You must supply a country in addition to a number to purchase a number"
-                );
-            }
+        if (!$country) {
+            throw new ClientException\Exception(
+                "You must supply a country in addition to a number to purchase a number"
+            );
+        }
+
+        if ($number instanceof Number) {
 
             trigger_error(
                 'Passing a Number object to Vonage\Number\Client::purchase() is being deprecated, ' .
@@ -232,13 +231,18 @@ class Client implements APIClient
                 E_USER_DEPRECATED
             );
 
-            $number = new Number($number, $country);
-        }
+            $body = [
+                'msisdn' => $number->getMsisdn(),
+                'country' => $number->getCountry()
+            ];
+        // Evil else that will be removed in the next major version.
+        } else {
 
-        $body = [
-            'msisdn' => $number->getMsisdn(),
-            'country' => $number->getCountry()
-        ];
+            $body = [
+                'msisdn' => $number,
+                'country' => $country
+            ];
+        }
 
         $api = $this->getApiResource();
         $api->setBaseUri('/number/buy');

--- a/test/Numbers/ClientTest.php
+++ b/test/Numbers/ClientTest.php
@@ -426,9 +426,7 @@ class ClientTest extends VonageTestCase
             return true;
         }))->willReturn($this->getResponse('post'));
 
-        $number = new Number('1415550100', 'US');
-        $this->numberClient->purchase($number);
-
+        $this->numberClient->purchase('1415550100', 'US');
         // There's nothing to assert here as we don't do anything with the response.
         // If there's no exception thrown, everything is fine!
     }
@@ -454,7 +452,8 @@ class ClientTest extends VonageTestCase
             }
             return false;
         }))->willReturn($this->getResponse('post'));
-        @$this->numberClient->purchase('1415550100', 'US');
+
+        $this->numberClient->purchase('1415550100', 'US');
 
         // There's nothing to assert here as we don't do anything with the response.
         // If there's no exception thrown, everything is fine!
@@ -491,8 +490,7 @@ class ClientTest extends VonageTestCase
         $this->expectException($expectedException);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
-        $num = new Number($number, $country);
-        @$this->numberClient->purchase($num);
+        $this->numberClient->purchase($number, $country);
     }
 
     public function purchaseNumberErrorProvider(): array


### PR DESCRIPTION
This is a follow up to #396, that corrects the full flow to work correctly.

## Description
A deprecation message exists for passing in a Number object, but still relies on it's setter methods for the body that is passed in the API Request. This PR fixes that.

## How Has This Been Tested?
Tests fixed to reflect correct behaviour

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
