### PR TITLE
scts is an optional property

### DIFF
--- a/src/SMS/Webhook/DeliveryReceipt.php
+++ b/src/SMS/Webhook/DeliveryReceipt.php
@@ -151,7 +151,6 @@ class DeliveryReceipt
         'msisdn',
         'network-code',
         'price',
-        'scts',
         'status',
         'to'
     ];
@@ -230,13 +229,16 @@ class DeliveryReceipt
         $this->msisdn = $data['msisdn'];
         $this->networkCode = $data['network-code'];
         $this->price = $data['price'];
-        $this->scts = $data['scts'];
         $this->status = $data['status'];
         $this->to = $data['to'];
         $this->apiKey = $data['api-key'];
 
         if (isset($data['client-ref'])) {
             $this->clientRef = $data['client-ref'];
+        }
+
+        if (isset($data['scts'])) {
+            $this->scts = $data['scts'];
         }
     }
 


### PR DESCRIPTION
Small PR to make stcs optional, as this field sometimes does not return based on the carrier response.

## Motivation and Context
The field not being optional right now stops the webhook object for delivery being successfully hydrated.

## How Has This Been Tested?
All tests pass, no need to tweak them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
