### PR TITLE
Pull out whole response from SMSCollection

### DIFF
--- a/src/SMS/Collection.php
+++ b/src/SMS/Collection.php
@@ -61,4 +61,9 @@ class Collection implements Countable, Iterator
     {
         return isset($this->data['messages'][$this->current]);
     }
+
+    public function getAllMessagesRaw(): array
+    {
+        return $this->data;
+    }
 }


### PR DESCRIPTION
As requested in #412 , this PR allows the user to pull out the raw response from sending an SMS.

## Description
The SDKs are written in such as way as to help the developer integrate Vonage APIs in a more verbose, PHP way.
However, there a possibly times when a developer wants to get access to something protected. Some inner workings of the SDK will remain private and the whole point is that the developer doesn't need to worry about those things.

In this case though, there is no harm in extracting the raw response from an SMS Collection object.
You can now get this response out with `$response->getAllMessagesRaw()` method.

## How Has This Been Tested?
Additional test added for this usage.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
