### PR TITLE
Reintroduce phpstan, add baseline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     "squizlabs/php_codesniffer": "^3.5",
     "softcreatr/jsonpath": "^0.7 || ^0.8",
     "phpspec/prophecy-phpunit": "^2.0",
-    "phpstan/phpstan": "^1.9",
-    "rector/rector": "^0.14.8"
+    "rector/rector": "^0.14.8",
+    "phpstan/phpstan": "^1.10"
   },
   "config": {
     "optimize-autoloader": true,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,76 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to an undefined property Vonage\\\\Account\\\\Price\\:\\:\\$priceMethod\\.$#"
+			count: 1
+			path: src/Account/Price.php
+
+		-
+			message: "#^Result of method Vonage\\\\Account\\\\Price\\:\\:getResponse\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: src/Account/Price.php
+
+		-
+			message: "#^Access to an undefined property Vonage\\\\Application\\\\Application\\:\\:\\$data\\.$#"
+			count: 1
+			path: src/Application/Application.php
+
+		-
+			message: "#^Call to an undefined method Vonage\\\\Application\\\\Client\\:\\:fromArray\\(\\)\\.$#"
+			count: 1
+			path: src/Application/Client.php
+
+		-
+			message: "#^Instantiated class Http\\\\Adapter\\\\Guzzle6\\\\Client not found\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method Vonage\\\\Client\\:\\:setLogger\\(\\) should return Vonage\\\\Logger\\\\LoggerAwareInterface but return statement is missing\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: src/Client/Callback/Callback.php
+
+		-
+			message: "#^Access to an undefined property Vonage\\\\Client\\\\Exception\\\\Request\\:\\:\\$data\\.$#"
+			count: 1
+			path: src/Client/Exception/Request.php
+
+		-
+			message: "#^Call to an undefined method \\$this\\(Vonage\\\\Client\\\\Exception\\\\Request\\)&Vonage\\\\Entity\\\\Hydrator\\\\ArrayHydrateInterface\\:\\:getResponseData\\(\\)\\.$#"
+			count: 1
+			path: src/Client/Exception/Request.php
+
+		-
+			message: "#^Access to an undefined property Vonage\\\\Client\\\\Exception\\\\Server\\:\\:\\$data\\.$#"
+			count: 1
+			path: src/Client/Exception/Server.php
+
+		-
+			message: "#^Call to an undefined method \\$this\\(Vonage\\\\Client\\\\Exception\\\\Server\\)&Vonage\\\\Entity\\\\Hydrator\\\\ArrayHydrateInterface\\:\\:getResponseData\\(\\)\\.$#"
+			count: 1
+			path: src/Client/Exception/Server.php
+
+		-
+			message: "#^Result of method Vonage\\\\Network\\:\\:getResponse\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: src/Network.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: src/Network/Number/Response.php
+
+		-
+			message: "#^Result of method Vonage\\\\Numbers\\\\Number\\:\\:getResponse\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: src/Numbers/Number.php
+
+		-
+			message: "#^Access to an undefined property Vonage\\\\Verify\\\\Verification\\:\\:\\$data\\.$#"
+			count: 1
+			path: src/Verify/Verification.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: 0
+	paths:
+		- src


### PR DESCRIPTION
This PR adds the basic configuration for PHPStan and the baseline file.

## Description
Baseline is set to 0, the config specifies that we only want PHPStan to work with the `src` folder (tests do weird and wonderful things that are -supposed- to be bad)

## Motivation and Context
Code Quality evolution of the Vonage PHP Library with the next step to run in the pipeline for PRs

## How Has This Been Tested?
Tests not relevent

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
