### PR TITLE
add permissions to take out write-all in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,19 @@ name: build
 
 on: [ push, pull_request ]
 
+permissions:
+  actions: write
+  checks: write
+  contents: read
+  deployments: read
+  issues: write
+  discussions: write
+  packages: read
+  pages: write
+  pull-requests: write
+  security-events: write
+  statuses: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,19 @@ on:
   release:
     types: [ published, edited ]
 
+permissions:
+  actions: write
+  checks: write
+  contents: read
+  deployments: read
+  issues: write
+  discussions: write
+  packages: read
+  pages: write
+  pull-requests: write
+  security-events: write
+  statuses: write
+
 jobs:
   add-changelog:
     name: Add Changelog


### PR DESCRIPTION
IaC reports that Github workflow for CI does not have permissions set, resulting in write-all by default.

## Description
Adds permissions with some restrictions to contents, deployments and packages.

## Motivation and Context
Security audit results

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
