### PR TITLE
make keyword nullable in InboundSMS.php

### DIFF
--- a/src/SMS/Webhook/InboundSMS.php
+++ b/src/SMS/Webhook/InboundSMS.php
@@ -25,7 +25,6 @@ class InboundSMS
         'messageId',
         'text',
         'type',
-        'keyword',
         'message-timestamp'
     ];
 
@@ -60,7 +59,7 @@ class InboundSMS
     protected $data;
 
     /**
-     * @var string
+     * @var ?string
      */
     protected $keyword;
 
@@ -126,7 +125,6 @@ class InboundSMS
         }
 
         $this->apiKey = $data['api-key'] ?? null;
-        $this->keyword = $data['keyword'];
         $this->messageId = $data['messageId'];
         $this->messageTimestamp = new DateTimeImmutable($data['message-timestamp']);
         $this->msisdn = $data['msisdn'];
@@ -146,6 +144,10 @@ class InboundSMS
         if ($this->type === 'binary' && array_key_exists('data', $data)) {
             $this->data = $data['data'];
             $this->udh = $data['udh'];
+        }
+
+        if (array_key_exists('keyword', $data)) {
+            $this->keyword = $data['keyword'];
         }
 
         if (array_key_exists('timestamp', $data)) {
@@ -183,7 +185,7 @@ class InboundSMS
         return $this->data;
     }
 
-    public function getKeyword(): string
+    public function getKeyword(): ?string
     {
         return $this->keyword;
     }


### PR DESCRIPTION
Another small PR to make `keyword` nullable when hydrating an InboundSMS webhook.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
