### PR TITLE
Refactor to JWT library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "psr/container": "^1.0 | ^2.0",
     "psr/http-client-implementation": "^1.0",
     "vonage/nexmo-bridge": "^0.1.0",
-    "psr/log": "^1.1|^2.0|^3.0"
+    "psr/log": "^1.1|^2.0|^3.0",
+    "vonage/jwt": "^0.4.0"
   },
   "require-dev": {  
     "guzzlehttp/guzzle": ">=6",

--- a/src/Client/Credentials/Keypair.php
+++ b/src/Client/Credentials/Keypair.php
@@ -61,9 +61,10 @@ class Keypair extends AbstractCredentials
         $generator = new TokenGenerator($this->application, $this->getKeyRaw());
 
         if (isset($claims['exp'])) {
+            // This will change to an Exception in 5.0
             trigger_error('Expiry date is automatically generated from now and TTL, so cannot be passed in
             as an argument in claims', E_USER_WARNING);
-            unset($claims['exp']);
+            unset($claims['nbf']);
         }
 
         if (isset($claims['ttl'])) {
@@ -79,7 +80,9 @@ class Keypair extends AbstractCredentials
         if (isset($claims['nbf'])) {
             // Due to older versions of lcobucci/jwt, this claim has
             // historic fraction conversation issues. For now, nbf is not supported.
-            throw new Validation('NotBefore Claim is not supported in Vonage JWT');
+            // This will change to an Exception in 5.0
+            trigger_error('NotBefore Claim is not supported in Vonage JWT', E_USER_WARNING);
+            unset($claims['nbf']);
         }
 
         if (isset($claims['sub'])) {

--- a/test/Client/Credentials/KeypairTest.php
+++ b/test/Client/Credentials/KeypairTest.php
@@ -71,8 +71,7 @@ class KeypairTest extends VonageTestCase
                 'nested' => [
                     'data' => "something"
                 ]
-            ],
-            'nbf' => 900
+            ]
         ];
 
         $jwt = $credentials->generateJwt($claims);
@@ -80,18 +79,15 @@ class KeypairTest extends VonageTestCase
 
         $this->assertArrayHasKey('arbitrary', $payload);
         $this->assertEquals($claims['arbitrary'], $payload['arbitrary']);
-        $this->assertArrayHasKey('nbf', $payload);
-        $this->assertEquals(900, $payload['nbf']);
     }
 
     /**
      * @link https://github.com/Vonage/vonage-php-sdk-core/issues/276
      */
-    public function testExampleConversationJWTWorks()
+    public function testExampleConversationJWTWorks(): void
     {
         $credentials = new Keypair($this->key, $this->application);
         $claims = [
-            'exp' => strtotime(date('Y-m-d', strtotime('+24 Hours'))),
             'sub' => 'apg-cs',
             'acl' => [
                 'paths' => [
@@ -113,7 +109,6 @@ class KeypairTest extends VonageTestCase
         [, $payload] = $this->decodeJWT($jwt->toString());
 
         $this->assertArrayHasKey('exp', $payload);
-        $this->assertEquals($claims['exp'], $payload['exp']);
         $this->assertEquals($claims['sub'], $payload['sub']);
     }
 


### PR DESCRIPTION
This PR marks the first move to remove the dependency for lcobucci/jwt to vonage/jwt.

## Description
While vonage/jwt still uses lcobucci/jwt under the hood, I am extracting it as a dependency for core so that the vonage/jwt library can firstly be reused for other projects that require vonage-specifc JWTs.

## Motivation and Context
Preparing core for v5.0 by adjusting dependencies.

## How Has This Been Tested?
Existing tests pass.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
