### PR TITLE
Add support for lcobucci/jwt 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": "~8.0 || ~8.1 || ~8.2", 
     "ext-mbstring": "*",
     "laminas/laminas-diactoros": "^3.0",
-    "lcobucci/jwt": "^3.4|^4.0",
+    "lcobucci/jwt": "^4.0|^5.0",
     "psr/container": "^1.0 | ^2.0",
     "psr/http-client-implementation": "^1.0",
     "vonage/nexmo-bridge": "^0.1.0",

--- a/src/Client/Credentials/Keypair.php
+++ b/src/Client/Credentials/Keypair.php
@@ -81,30 +81,30 @@ class Keypair extends AbstractCredentials
             unset($claims['jti']);
         }
 
-        $builder = $config->builder();
-        $builder->issuedAt((new \DateTimeImmutable())->setTimestamp($iat))
+        $builder = $config->builder()
+            ->issuedAt((new \DateTimeImmutable())->setTimestamp($iat))
             ->expiresAt((new \DateTimeImmutable())->setTimestamp($exp))
             ->identifiedBy($jti);
 
         if (isset($claims['nbf'])) {
-            $builder->canOnlyBeUsedAfter((new \DateTimeImmutable())->setTimestamp($claims['nbf']));
+            $builder = $builder->canOnlyBeUsedAfter((new \DateTimeImmutable())->setTimestamp($claims['nbf']));
 
             unset($claims['nbf']);
         }
 
         if (isset($this->credentials['application'])) {
-            $builder->withClaim('application_id', $this->credentials['application']);
+            $builder = $builder->withClaim('application_id', $this->credentials['application']);
         }
 
         if (isset($claims['sub'])) {
-            $builder->relatedTo($claims['sub']);
+            $builder =$builder->relatedTo($claims['sub']);
 
             unset($claims['sub']);
         }
 
         if (!empty($claims)) {
             foreach ($claims as $claim => $value) {
-                $builder->withClaim($claim, $value);
+                $builder = $builder->withClaim($claim, $value);
             }
         }
 

--- a/src/Client/Credentials/Keypair.php
+++ b/src/Client/Credentials/Keypair.php
@@ -97,7 +97,7 @@ class Keypair extends AbstractCredentials
         }
 
         if (isset($claims['sub'])) {
-            $builder =$builder->relatedTo($claims['sub']);
+            $builder = $builder->relatedTo($claims['sub']);
 
             unset($claims['sub']);
         }


### PR DESCRIPTION
This PR allows us to install it with `lcobucci/jwt` v5.

## Description

It does what title says :) It also removes allowance of `lcobucci/jwt` v3 since [it might be installed only on PHP `^7.0`](https://github.com/lcobucci/jwt/blob/3ef8657a78278dfeae7707d51747251db4176240/composer.json#L20), but the library itself [requires at least `^8.0`](https://github.com/Vonage/vonage-php-sdk-core/blob/9ebd5649d496d39f0155e874d1a9281069aca903/composer.json#L15).

## Motivation and Context

On our project we use the latest version of the `lcobucci/jwt`, so we couldn't install the library without this fix.

## How Has This Been Tested?

I have performed `vendor/bin/phpunit` for both 4 and 5 versions of `lcobucci/jwt`. No errors have been reported.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
