### PR TITLE
Add null check for appId getter on Number model

### DIFF
--- a/src/Numbers/Number.php
+++ b/src/Numbers/Number.php
@@ -296,6 +296,6 @@ class Number implements EntityInterface, JsonSerializableInterface, JsonUnserial
     public function getAppId(): ?string
     {
         // These should never be different, but might not both be set
-        return $this->data['voiceCallbackValue'] ?? $this->data['messagesCallbackValue'];
+        return $this->data['voiceCallbackValue'] ?? $this->data['messagesCallbackValue'] ?? null;
     }
 }


### PR DESCRIPTION
## Description
When the number isn't linked to the application, there are no fields `voiceCallbackValue` and `messagesCallbackValue`, so calling `Number::getAppId()` produces an error on access to not existing array key.

## Motivation and Context
I need this functionality so I fix it.

## How Has This Been Tested?
I tried it with my codebase.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
