### PR TITLE
lcobucci/jwt v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": "~8.0 || ~8.1 || ~8.2", 
     "ext-mbstring": "*",
     "laminas/laminas-diactoros": "^3.0",
-    "lcobucci/jwt": "^3.4|^4.0",
+    "lcobucci/jwt": "^4.0|^5.0",
     "psr/container": "^1.0 | ^2.0",
     "psr/http-client-implementation": "^1.0",
     "vonage/nexmo-bridge": "^0.1.0",

--- a/src/Client/Credentials/Keypair.php
+++ b/src/Client/Credentials/Keypair.php
@@ -81,30 +81,30 @@ class Keypair extends AbstractCredentials
             unset($claims['jti']);
         }
 
-        $builder = $config->builder();
-        $builder->issuedAt((new \DateTimeImmutable())->setTimestamp($iat))
+        $builder = $config->builder()
+            ->issuedAt((new \DateTimeImmutable())->setTimestamp($iat))
             ->expiresAt((new \DateTimeImmutable())->setTimestamp($exp))
             ->identifiedBy($jti);
 
         if (isset($claims['nbf'])) {
-            $builder->canOnlyBeUsedAfter((new \DateTimeImmutable())->setTimestamp($claims['nbf']));
+            $builder = $builder->canOnlyBeUsedAfter((new \DateTimeImmutable())->setTimestamp($claims['nbf']));
 
             unset($claims['nbf']);
         }
 
         if (isset($this->credentials['application'])) {
-            $builder->withClaim('application_id', $this->credentials['application']);
+            $builder = $builder->withClaim('application_id', $this->credentials['application']);
         }
 
         if (isset($claims['sub'])) {
-            $builder->relatedTo($claims['sub']);
+            $builder =$builder->relatedTo($claims['sub']);
 
             unset($claims['sub']);
         }
 
         if (!empty($claims)) {
             foreach ($claims as $claim => $value) {
-                $builder->withClaim($claim, $value);
+                $builder = $builder->withClaim($claim, $value);
             }
         }
 

--- a/src/Client/Credentials/Keypair.php
+++ b/src/Client/Credentials/Keypair.php
@@ -97,7 +97,7 @@ class Keypair extends AbstractCredentials
         }
 
         if (isset($claims['sub'])) {
-            $builder =$builder->relatedTo($claims['sub']);
+            $builder = $builder->relatedTo($claims['sub']);
 
             unset($claims['sub']);
         }


### PR DESCRIPTION
## Description
After merging https://github.com/Vonage/vonage-php-sdk-core/pull/441 there is no reason not to allow v5 of `lcobucci/jwt`.

## Motivation and Context
I still need v5 of that library on my project :)

## How Has This Been Tested?
Yes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
