### PR TITLE
Fix async behavior of the NCCO record action

### DIFF
--- a/src/Voice/NCCO/Action/Record.php
+++ b/src/Voice/NCCO/Action/Record.php
@@ -53,7 +53,7 @@ class Record implements ActionInterface
     /**
      * @var int
      */
-    protected $timeOut = 7200;
+    protected $timeOut = 0;
 
     /**
      * @var bool
@@ -133,9 +133,12 @@ class Record implements ActionInterface
         $data = [
             'action' => 'record',
             'format' => $this->getFormat(),
-            'timeOut' => (string)$this->getTimeout(),
             'beepStart' => $this->getBeepStart() ? 'true' : 'false',
         ];
+
+        if ($this->getTimeout() !== 0) {
+            $data['timeOut'] = (string)$this->getTimeout();
+        }
 
         if ($this->getEndOnSilence()) {
             $data['endOnSilence'] = (string)$this->getEndOnSilence();

--- a/test/Voice/NCCO/Action/RecordTest.php
+++ b/test/Voice/NCCO/Action/RecordTest.php
@@ -30,12 +30,20 @@ class RecordTest extends VonageTestCase
 
     public function testJsonSerializeLooksCorrect(): void
     {
+        $record = new Record();
         $this->assertSame([
             'action' => 'record',
             'format' => 'mp3',
-            'timeOut' => '7200',
             'beepStart' => 'false'
-        ], (new Record())->jsonSerialize());
+        ], $record->jsonSerialize());
+
+        $record->setTimeout(1234);
+        $this->assertSame([
+            'action' => 'record',
+            'format' => 'mp3',
+            'beepStart' => 'false',
+            'timeOut' => '1234'
+        ], $record->jsonSerialize());
     }
 
     public function testSettingChannelBackToOneResetsValues(): void


### PR DESCRIPTION
## Description
As described in the [documentation](https://developer.vonage.com/en/voice/voice-api/ncco-reference#record), the `record` action is asynchronous by default, unless it has `endOnSilence`, `timeOut` or `endOnKey` params. The current implementation of the `Record` action in this library provides no way to not specify that param.

## Motivation and Context
We need to achieve an async behavior of the record action.

## How Has This Been Tested?
We have made calls with those changes.

## Example Output or Screenshots (if appropriate):
Call `CON-b4cc19a0-ffd7-4e44-80ec-2d7ecf05c44c`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
