### PR TITLE
Allow to do numbers filtering with has_application and application_id filters

### DIFF
--- a/src/Numbers/Filter/AvailableNumbers.php
+++ b/src/Numbers/Filter/AvailableNumbers.php
@@ -74,6 +74,10 @@ class AvailableNumbers implements FilterInterface
      */
     protected $type;
 
+    protected ?bool $hasApplication = null;
+
+    protected ?string $applicationId = null;
+
     public function __construct(array $filter = [])
     {
         foreach ($filter as $key => $value) {
@@ -132,6 +136,14 @@ class AvailableNumbers implements FilterInterface
 
             $this->setFeatures($filter['features']);
         }
+
+        if (array_key_exists('has_application', $filter)) {
+            $this->setHasApplication((bool)$filter['has_application']);
+        }
+
+        if (array_key_exists('application_id', $filter)) {
+            $this->setApplicationId($filter['application_id']);
+        }
     }
 
     /**
@@ -159,6 +171,14 @@ class AvailableNumbers implements FilterInterface
 
         if ($this->getFeatures()) {
             $data['features'] = $this->getFeatures();
+        }
+
+        if ($this->getHasApplication() !== null) {
+            $data['has_application'] = $this->getHasApplication();
+        }
+
+        if ($this->getApplicationId() !== null) {
+            $data['application_id'] = $this->getApplicationId();
         }
 
         return $data;
@@ -279,6 +299,36 @@ class AvailableNumbers implements FilterInterface
     public function setPageSize(int $pageSize): self
     {
         $this->pageSize = $pageSize;
+
+        return $this;
+    }
+
+    public function getHasApplication(): ?bool
+    {
+        return $this->hasApplication;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setHasApplication(bool $hasApplication): self
+    {
+        $this->hasApplication = $hasApplication;
+
+        return $this;
+    }
+
+    public function getApplicationId(): ?string
+    {
+        return $this->applicationId;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setApplicationId(string $applicationId): self
+    {
+        $this->applicationId = $applicationId;
 
         return $this;
     }

--- a/test/Numbers/Filter/AvailableNumbersTest.php
+++ b/test/Numbers/Filter/AvailableNumbersTest.php
@@ -42,4 +42,26 @@ class AvailableNumbersTest extends VonageTestCase
         $filter = new AvailableNumbers();
         $filter->setType('foo-bar');
     }
+
+    public function testCanSetHasApplication(): void
+    {
+        $filter = new AvailableNumbers();
+        $filter->setHasApplication(true);
+
+        $this->assertTrue($filter->getHasApplication());
+        $query = $filter->getQuery();
+        $this->assertArrayHasKey('has_application', $query);
+        $this->assertTrue($query['has_application']);
+    }
+
+    public function testCanSetApplicationId(): void
+    {
+        $filter = new AvailableNumbers();
+        $filter->setApplicationId('xxxxxxxx');
+
+        $this->assertSame('xxxxxxxx', $filter->getApplicationId());
+        $query = $filter->getQuery();
+        $this->assertArrayHasKey('application_id', $query);
+        $this->assertSame('xxxxxxxx', $query['application_id']);
+    }
 }


### PR DESCRIPTION
## Description
Those two filters are [listed here](https://developer.vonage.com/en/api/numbers#getOwnedNumbers), but not available in this library. My PR fixes that.

## Motivation and Context
My company need that.

## How Has This Been Tested?
I have tested it by searching purchased phone numbers with those filters.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
