### PR TITLE
remove verification checks, API behaviour too unstable currently

### DIFF
--- a/src/Verify2/VerifyObjects/VerificationLocale.php
+++ b/src/Verify2/VerifyObjects/VerificationLocale.php
@@ -4,51 +4,8 @@ namespace Vonage\Verify2\VerifyObjects;
 
 class VerificationLocale
 {
-    private array $allowedCodes = [
-        'fr-fr',
-        'en-gb',
-        'en-us',
-        'es-es',
-        'es-us',
-        'it-it',
-        'de-de',
-        'pt-br',
-        'pt-pt',
-        'ru-ru',
-        'hi-in',
-        'id-id',
-        'he-il',
-        'yue-cn',
-        'ja-jp',
-        'ar-xa',
-        'cs-cz',
-        'cy-gb',
-        'el-gr',
-        'en-au',
-        'en-in',
-        'es-mx',
-        'fi-fi',
-        'fil-ph',
-        'fr-ca',
-        'hu-hu',
-        'is-is',
-        'nb-no',
-        'nl-nl',
-        'pl-pl',
-        'ro-ro',
-        'sv-se',
-        'th-th',
-        'tr-tr',
-        'vi-vn',
-        'zh-cn',
-        'zh-tw'
-    ];
-
     public function __construct(protected string $code = 'en-us')
     {
-        if (! in_array($code, $this->allowedCodes, true)) {
-            throw new \InvalidArgumentException('Invalid Locale Code Provided');
-        }
     }
 
     public function getCode(): string

--- a/test/Verify2/ClientTest.php
+++ b/test/Verify2/ClientTest.php
@@ -139,45 +139,6 @@ class ClientTest extends VonageTestCase
     }
 
     /**
-     * @dataProvider localeProvider
-     */
-    public function testCannotRequestSMSWithInvalidLocale($locale, $valid): void
-    {
-        if (!$valid) {
-            $this->expectException(\InvalidArgumentException::class);
-        }
-
-        $verificationLocale = new VerificationLocale($locale);
-
-        $payload = [
-            'to' => '07785254785',
-            'client_ref' => 'my-verification',
-            'brand' => 'my-brand',
-            'locale' => $verificationLocale,
-        ];
-
-        $smsVerification = new SMSRequest($payload['to'], $payload['brand'], $payload['locale']);
-        $smsVerification->setClientRef($payload['client_ref']);
-
-        $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
-            $this->assertEquals(
-                'Basic ',
-                mb_substr($request->getHeaders()['Authorization'][0], 0, 6)
-            );
-
-            $this->assertRequestJsonBodyContains('locale', $payload['locale']->getCode(), $request);
-            $this->assertEquals('POST', $request->getMethod());
-
-            return true;
-        }))->willReturn($this->getResponse('verify-request-success', 202));
-
-        $result = $this->verify2Client->startVerification($smsVerification);
-
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('request_id', $result);
-    }
-
-    /**
      * @dataProvider timeoutProvider
      */
     public function testTimeoutParsesCorrectly($timeout, $valid): void


### PR DESCRIPTION
This PR removes the server-side SDK check for supported locales on the basis that the Verify V2 API currently has some unexpected behaviour.

## Description
You now supply a locale - if you don't, `en-us` is chosen. At the time of writing, the Vonage API will scan the `to` field in a workflow and choose your locale for you.

## Motivation and Context
Attempt to get some consistency - right now, the emphasis here is for the API to handle error handling rather than the SDK to do it at the time of execution (before a call is made)

## How Has This Been Tested?
Test to make sure you can give a valid locale has been removed.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
