### PR TITLE
Add ability to add optional redirect url

### DIFF
--- a/src/Verify2/Request/SilentAuthRequest.php
+++ b/src/Verify2/Request/SilentAuthRequest.php
@@ -9,8 +9,14 @@ class SilentAuthRequest extends BaseVerifyRequest
     public function __construct(
         protected string $to,
         protected string $brand,
+        protected ?string $redirectUrl = null
     ) {
         $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_SILENT_AUTH, $to);
+
+        if ($this->redirectUrl) {
+            $workflow->setCustomKeys(['redirect_url' => $this->redirectUrl]);
+        }
+
         $this->addWorkflow($workflow);
     }
 

--- a/src/Verify2/VerifyObjects/VerificationWorkflow.php
+++ b/src/Verify2/VerifyObjects/VerificationWorkflow.php
@@ -25,7 +25,8 @@ class VerificationWorkflow implements ArrayHydrateInterface
     public function __construct(
         protected string $channel,
         protected string $to,
-        protected string $from = ''
+        protected string $from = '',
+        protected array $customKeys = []
     ) {
         if (! in_array($channel, $this->allowedWorkflows, true)) {
             throw new \InvalidArgumentException($this->channel . ' is not a valid workflow');
@@ -91,6 +92,24 @@ class VerificationWorkflow implements ArrayHydrateInterface
             $returnArray['from'] = $this->getFrom();
         }
 
+        if (!empty($this->customKeys)) {
+            foreach ($this->customKeys as $key => $value) {
+                $returnArray[$key] = $value;
+            }
+        }
+
         return $returnArray;
+    }
+
+    public function getCustomKeys(): array
+    {
+        return $this->customKeys;
+    }
+
+    public function setCustomKeys(array $customKeys): self
+    {
+        $this->customKeys = $customKeys;
+
+        return $this;
     }
 }


### PR DESCRIPTION
This PR allows Verify v2 requests for Silent Auth to go out with the optional `redirect_url`

## Description
The option modifies the VerificationWorkflow object to allow custom keys to be added (which are likely to be soon used in other Verify channels)

## Motivation and Context
New parameter that is already available

## How Has This Been Tested?
New test added to make sure that the outgoing response has the correct key

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
