### PR TITLE
Autoload video module if it is installed

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -90,6 +90,7 @@ use function strpos;
  * @method Verify\Client  verify()
  * @method Verify2\Client  verify2()
  * @method Voice\Client voice()
+ * @method Vonage\Video\Client video()
  *
  * @property string restUrl
  * @property string apiUrl
@@ -211,29 +212,39 @@ class Client implements LoggerAwareInterface
             $this->debug = $options['debug'];
         }
 
+        $services = [
+            // Registered Services by name
+            'account' => ClientFactory::class,
+            'applications' => ApplicationClientFactory::class,
+            'conversion' => ConversionClientFactory::class,
+            'insights' => InsightsClientFactory::class,
+            'numbers' => NumbersClientFactory::class,
+            'meetings' => MeetingsClientFactory::class,
+            'messages' => MessagesClientFactory::class,
+            'redact' => RedactClientFactory::class,
+            'secrets' => SecretsClientFactory::class,
+            'sms' => SMSClientFactory::class,
+            'subaccount' => SubaccountClientFactory::class,
+            'users' => UsersClientFactory::class,
+            'verify' => VerifyClientFactory::class,
+            'verify2' => Verify2ClientFactory::class,
+            'voice' => VoiceClientFactory::class,
+
+            // Additional utility classes
+            APIResource::class => APIResource::class,
+        ];
+
+        if (class_exists('Vonage\Video\ClientFactory')) {
+            $services['video'] = 'Vonage\Video\ClientFactory';
+        } else {
+            $services['video'] = function() {
+                throw new \RuntimeException('Please install @vonage/video to use the Video API');
+            };
+        }
+
         $this->setFactory(
             new MapFactory(
-                [
-                    // Registered Services by name
-                    'account' => ClientFactory::class,
-                    'applications' => ApplicationClientFactory::class,
-                    'conversion' => ConversionClientFactory::class,
-                    'insights' => InsightsClientFactory::class,
-                    'numbers' => NumbersClientFactory::class,
-                    'meetings' => MeetingsClientFactory::class,
-                    'messages' => MessagesClientFactory::class,
-                    'redact' => RedactClientFactory::class,
-                    'secrets' => SecretsClientFactory::class,
-                    'sms' => SMSClientFactory::class,
-                    'subaccount' => SubaccountClientFactory::class,
-                    'users' => UsersClientFactory::class,
-                    'verify' => VerifyClientFactory::class,
-                    'verify2' => Verify2ClientFactory::class,
-                    'voice' => VoiceClientFactory::class,
-
-                    // Additional utility classes
-                    APIResource::class => APIResource::class,
-                ],
+                $services,
                 $this
             )
         );

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Vonage Client Library for PHP
+ *
+ * @copyright Copyright (c) 2016-2023 Vonage, Inc. (http://vonage.com)
+ * @license https://github.com/Vonage/vonage-php-sdk-core/blob/master/LICENSE.txt Apache License 2.0
+ */
+
+declare(strict_types=1);
+
+namespace VonageTest;
+
+use RuntimeException;
+use VonageTest\VonageTestCase;
+use Vonage\Client;
+use Vonage\Client\Credentials\Basic;
+
+class ClientTest extends VonageTestCase
+{
+    /**
+     * Make sure that when calling the video module it errors if the class isn't found
+     */
+    public function testCallingVideoWithoutPackageGeneratesRuntimeError(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Please install @vonage/video to use the Video API');
+
+        $client = new Client(new Basic('abcd', '1234'));
+        $video = $client->video();
+    }    
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For the new unified Video API, the package is stored in a separate repo and package. This adds in the ability to automatically map it to `$vonage->video()` if we detect it is installed alongside the core SDK.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows a user to more easily set up the video SDK instead of bootstrapping it themselves.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, manually

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
