### PR TITLE
From can now be added for sender_id on Verify2 SMS

### DIFF
--- a/src/Verify2/Request/SMSRequest.php
+++ b/src/Verify2/Request/SMSRequest.php
@@ -11,12 +11,13 @@ class SMSRequest extends BaseVerifyRequest
         protected string $to,
         protected string $brand,
         protected ?VerificationLocale $locale = null,
+        protected string $from = '',
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }
 
-        $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_SMS, $to);
+        $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_SMS, $to, $from);
 
         $this->addWorkflow($workflow);
     }

--- a/test/Verify2/ClientTest.php
+++ b/test/Verify2/ClientTest.php
@@ -84,9 +84,10 @@ class ClientTest extends VonageTestCase
             'to' => '07785254785',
             'client_ref' => 'my-verification',
             'brand' => 'my-brand',
+            'from' => 'vonage'
         ];
 
-        $smsVerification = new SMSRequest($payload['to'], $payload['brand']);
+        $smsVerification = new SMSRequest($payload['to'], $payload['brand'], null, $payload['from']);
         $smsVerification->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
@@ -104,6 +105,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('code_length', 4, $request);
             $this->assertRequestJsonBodyContains('brand', $payload['brand'], $request);
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request, true);
+            $this->assertRequestJsonBodyContains('from', $payload['from'], $request, true);
             $this->assertRequestJsonBodyContains('channel', 'sms', $request, true);
             $this->assertEquals('POST', $request->getMethod());
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This patch adds from as a field for Verify2 SMS

## Motivation and Context
Sender_ID parity requirements with Verify legacy

## How Has This Been Tested?
existing tests modified to check it gets sent out in the request

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
