### PR TITLE
Bump off PHP 8.0, add support for next vonage jwt lib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3']
         
     name: PHP ${{ matrix.php }} Test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '8.0', '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
 
     name: PHP ${{ matrix.php }} Test
 

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
     }
   ],
   "require": {
-    "php": "~8.0 || ~8.1 || ~8.2 || ~8.3", 
+    "php": "~8.1 || ~8.2 || ~8.3",
     "ext-mbstring": "*",
     "laminas/laminas-diactoros": "^3.0",
-    "lcobucci/jwt": "^3.4|^4.0|^5.0",
+    "lcobucci/jwt": "^4.0|^5.2.0",
     "psr/container": "^1.0 | ^2.0",
     "psr/http-client-implementation": "^1.0",
     "vonage/nexmo-bridge": "^0.1.0",
     "psr/log": "^1.1|^2.0|^3.0",
-    "vonage/jwt": "^0.4.0"
+    "vonage/jwt": "^0.5.0"
   },
   "require-dev": {  
     "guzzlehttp/guzzle": ">=6",


### PR DESCRIPTION
This PR drops support for PHP8.0 and adds in dependency bumps for JWTs

## Motivation and Context
Continued evolution of the SDK

## How Has This Been Tested?
Dependency changes require that the existing test suite passes.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
