### PR TITLE
Add Entity ID and Content ID to Verify V2

### DIFF
--- a/src/Verify2/Request/SMSRequest.php
+++ b/src/Verify2/Request/SMSRequest.php
@@ -12,12 +12,19 @@ class SMSRequest extends BaseVerifyRequest
         protected string $brand,
         protected ?VerificationLocale $locale = null,
         protected string $from = '',
+        protected string $entityId = '',
+        protected string $contentId = ''
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }
 
-        $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_SMS, $to, $from);
+        $customKeys = array_filter([
+            'entity_id' => $this->entityId,
+            'content_id' => $this->contentId
+        ]);
+
+        $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_SMS, $to, $from, $customKeys);
 
         $this->addWorkflow($workflow);
     }


### PR DESCRIPTION
This PR adds two new optional fields into the SMS Workflow for Verify.

## Description
`entity_id` and `content_id` can now be passed into the SMSWorkflow for 2FA processes using Indian carriers.

## Motivation and Context
Parity for Vonage APIs

## How Has This Been Tested?
New test added to make sure the request is made with the new keys.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
