### PR TITLE
New Messages API Features

### DIFF
--- a/src/Messages/Channel/BaseMessage.php
+++ b/src/Messages/Channel/BaseMessage.php
@@ -9,6 +9,13 @@ abstract class BaseMessage implements Message
     protected string $from;
     protected string $channel;
     protected ?string $clientRef = null;
+    protected ?string $webhookUrl = null;
+    protected ?string $webhookVersion = null;
+
+    protected array $permittedVersions = [
+        'v0.1',
+        'v1'
+    ];
 
     public const MESSAGES_SUBTYPE_TEXT = 'text';
     public const MESSAGES_SUBTYPE_IMAGE = 'image';
@@ -60,6 +67,30 @@ abstract class BaseMessage implements Message
         $this->to = $to;
     }
 
+    public function setWebhookUrl(string $url): void
+    {
+        $this->webhookUrl = $url;
+    }
+
+    public function getWebhookUrl(): ?string
+    {
+        return $this->webhookUrl;
+    }
+
+    public function setWebhookVersion(string $version): void
+    {
+        if (! in_array($version, $this->permittedVersions, true)) {
+            throw new \InvalidArgumentException($version . ' is not a valid webhook version');
+        }
+
+        $this->webhookVersion = $version;
+    }
+
+    public function getWebhookVersion(): ?string
+    {
+        return $this->webhookVersion;
+    }
+
     public function getBaseMessageUniversalOutputArray(): array
     {
         $returnArray = [
@@ -71,6 +102,14 @@ abstract class BaseMessage implements Message
 
         if ($this->getClientRef()) {
             $returnArray['client_ref'] = $this->getClientRef();
+        }
+
+        if ($this->getWebhookUrl()) {
+            $returnArray['webhook_url'] = $this->getWebhookUrl();
+        }
+
+        if ($this->getWebhookVersion()) {
+            $returnArray['webhook_version'] = $this->getWebhookVersion();
         }
 
         return $returnArray;

--- a/src/Messages/Channel/Message.php
+++ b/src/Messages/Channel/Message.php
@@ -22,6 +22,10 @@ interface Message
     public function getChannel(): string;
     public function getSubType(): string;
     public function setClientRef(string $clientRef): void;
+    public function getWebhookUrl(): ?string;
+    public function setWebhookUrl(string $url): void;
+    public function getWebhookVersion(): ?string;
+    public function setWebhookVersion(string $version): void;
 
     /**
      * All message types have shared outputs required by the endpoint.

--- a/src/Messages/Channel/SMS/SMSText.php
+++ b/src/Messages/Channel/SMS/SMSText.php
@@ -9,8 +9,18 @@ class SMSText extends BaseMessage
 {
     use TextTrait;
 
+    protected array $permittedEncodingTypes = [
+        'text',
+        'unicode',
+        'auto'
+    ];
+
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_TEXT;
     protected string $channel = 'sms';
+    protected ?int $ttl = null;
+    protected ?string $encodingType = null;
+    protected ?string $contentId = null;
+    protected ?string $entityId = null;
 
     public function __construct(
         string $to,
@@ -22,10 +32,70 @@ class SMSText extends BaseMessage
         $this->text = $message;
     }
 
+    public function getEncodingType(): ?string
+    {
+        return $this->encodingType;
+    }
+
+    public function setEncodingType(?string $encodingType): void
+    {
+        if (! in_array($encodingType, $this->permittedEncodingTypes, true)) {
+            throw new \InvalidArgumentException($encodingType . ' is not a valid encoding type');
+        }
+
+        $this->encodingType = $encodingType;
+    }
+
+    public function getContentId(): ?string
+    {
+        return $this->contentId;
+    }
+
+    public function setContentId(?string $contentId): void
+    {
+        $this->contentId = $contentId;
+    }
+
+    public function getEntityId(): ?string
+    {
+        return $this->entityId;
+    }
+
+    public function setEntityId(?string $entityId): void
+    {
+        $this->entityId = $entityId;
+    }
+
+    public function getTtl(): ?int
+    {
+        return $this->ttl;
+    }
+
+    public function setTtl(?int $ttl): void
+    {
+        $this->ttl = $ttl;
+    }
+
     public function toArray(): array
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['text'] = $this->getText();
+
+        if ($this->getEncodingType()) {
+            $returnArray['sms']['encoding_type'] = $this->getEncodingType();
+        }
+
+        if ($this->getContentId()) {
+            $returnArray['sms']['content_id'] = $this->getContentId();
+        }
+
+        if ($this->getEntityId()) {
+            $returnArray['sms']['entity_id'] = $this->getEntityId();
+        }
+
+        if ($this->getTtl()) {
+            $returnArray['ttl'] = $this->getTtl();
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/Viber/ViberFile.php
+++ b/src/Messages/Channel/Viber/ViberFile.php
@@ -4,6 +4,7 @@ namespace Vonage\Messages\Channel\Viber;
 
 use Vonage\Messages\MessageObjects\FileObject;
 use Vonage\Messages\Channel\BaseMessage;
+
 class ViberFile extends BaseMessage
 {
     use ViberServiceObjectTrait;
@@ -26,9 +27,9 @@ class ViberFile extends BaseMessage
         $returnArray['file'] = $this->fileObject->toArray();
 
         if ($this->requiresViberServiceObject()) {
-            $this->getCategory() ? $returnArray['viber_service']['category'] = $this->getCategory(): null;
-            $this->getTtl() ? $returnArray['viber_service']['ttl'] = $this->getTtl(): null;
-            $this->getType() ? $returnArray['viber_service']['type'] = $this->getType(): null;
+            $this->getCategory() ? $returnArray['viber_service']['category'] = $this->getCategory() : null;
+            $this->getTtl() ? $returnArray['viber_service']['ttl'] = $this->getTtl() : null;
+            $this->getType() ? $returnArray['viber_service']['type'] = $this->getType() : null;
         }
 
         return $returnArray;

--- a/src/Messages/Channel/Viber/ViberServiceObjectTrait.php
+++ b/src/Messages/Channel/Viber/ViberServiceObjectTrait.php
@@ -10,6 +10,8 @@ trait ViberServiceObjectTrait
     private ?int $ttl = null;
     private ?string $type = null;
     private ?ViberActionObject $action = null;
+    private string $duration;
+    private string $fileSize;
 
     public function requiresViberServiceObject(): bool
     {
@@ -62,5 +64,25 @@ trait ViberServiceObjectTrait
         $this->action = $viberActionObject;
 
         return $this;
+    }
+
+    public function getDuration(): string
+    {
+        return $this->duration;
+    }
+
+    public function setDuration(string $duration): void
+    {
+        $this->duration = $duration;
+    }
+
+    public function getFileSize(): string
+    {
+        return $this->fileSize;
+    }
+
+    public function setFileSize(string $fileSize): void
+    {
+        $this->fileSize = $fileSize;
     }
 }

--- a/src/Messages/Channel/Viber/ViberVideo.php
+++ b/src/Messages/Channel/Viber/ViberVideo.php
@@ -19,8 +19,12 @@ class ViberVideo extends BaseMessage
         string $to,
         string $from,
         string $thumbUrl,
-        protected VideoObject $videoObject
+        protected VideoObject $videoObject,
+        string $duration,
+        string $fileSize
     ) {
+        $this->fileSize = $fileSize;
+        $this->duration = $duration;
         $this->to = $to;
         $this->from = $from;
         $this->thumbUrl = $thumbUrl;
@@ -32,6 +36,14 @@ class ViberVideo extends BaseMessage
         $videoArray = $this->videoObject->toArray();
         $videoArray['thumb_url'] = $this->thumbUrl;
         $returnArray['video'] = $videoArray;
+
+        $returnArray['viber_service']['duration'] = $this->getDuration();
+        $returnArray['viber_service']['file_size'] = $this->getFileSize();
+
+        $this->getCategory() ? $returnArray['viber_service']['category'] = $this->getCategory() : null;
+        $this->getTtl() ? $returnArray['viber_service']['ttl'] = $this->getTtl() : null;
+        $this->getType() ? $returnArray['viber_service']['type'] = $this->getType() : null;
+        $this->getAction() ? $returnArray['viber_service']['action'] = $this->getAction()->toArray() : null;
 
         return $returnArray;
     }

--- a/src/Messages/MessageObjects/FileObject.php
+++ b/src/Messages/MessageObjects/FileObject.php
@@ -6,8 +6,11 @@ use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 
 class FileObject implements ArrayHydrateInterface
 {
-    public function __construct(private string $url, private string $caption = '')
-    {
+    public function __construct(
+        private string $url,
+        private string $caption = '',
+        private ?string $name = null,
+    ) {
     }
 
     public function fromArray(array $data): FileObject
@@ -16,6 +19,10 @@ class FileObject implements ArrayHydrateInterface
 
         if (isset($data['caption'])) {
             $this->caption = $data['caption'];
+        }
+
+        if (isset($data['name'])) {
+            $this->name = $data['name'];
         }
 
         return $this;
@@ -27,8 +34,12 @@ class FileObject implements ArrayHydrateInterface
             'url' => $this->url
         ];
 
-        if ($this->caption) {
-            $returnArray['caption'] = $this->caption;
+        if ($this->getCaption()) {
+            $returnArray['caption'] = $this->getCaption();
+        }
+
+        if ($this->getName()) {
+            $returnArray['name'] = $this->getName();
         }
 
         return $returnArray;
@@ -42,5 +53,15 @@ class FileObject implements ArrayHydrateInterface
     public function getCaption(): string
     {
         return $this->caption;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
     }
 }

--- a/src/Messages/MessageObjects/ImageObject.php
+++ b/src/Messages/MessageObjects/ImageObject.php
@@ -6,8 +6,10 @@ use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 
 class ImageObject implements ArrayHydrateInterface
 {
-    public function __construct(private string $url, private string $caption = '')
-    {
+    public function __construct(
+        private string $url,
+        private string $caption = '',
+    ) {
     }
 
     public function fromArray(array $data): ImageObject
@@ -27,8 +29,8 @@ class ImageObject implements ArrayHydrateInterface
             'url' => $this->url
         ];
 
-        if ($this->caption) {
-            $returnArray['caption'] = $this->caption;
+        if ($this->getCaption()) {
+            $returnArray['caption'] = $this->getCaption();
         }
 
         return $returnArray;

--- a/src/Messages/MessageObjects/VCardObject.php
+++ b/src/Messages/MessageObjects/VCardObject.php
@@ -6,8 +6,10 @@ use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 
 class VCardObject implements ArrayHydrateInterface
 {
-    public function __construct(private string $url)
-    {
+    public function __construct(
+        private string $url,
+        private ?string $caption = null
+    ) {
     }
 
     public function fromArray(array $data): VCardObject
@@ -27,5 +29,15 @@ class VCardObject implements ArrayHydrateInterface
     public function getUrl(): string
     {
         return $this->url;
+    }
+
+    public function getCaption(): ?string
+    {
+        return $this->caption;
+    }
+
+    public function setCaption(?string $caption): void
+    {
+        $this->caption = $caption;
     }
 }

--- a/src/Messages/MessageObjects/VideoObject.php
+++ b/src/Messages/MessageObjects/VideoObject.php
@@ -27,8 +27,8 @@ class VideoObject implements ArrayHydrateInterface
             'url' => $this->url
         ];
 
-        if ($this->caption) {
-            $returnArray['caption'] = $this->caption;
+        if ($this->getCaption()) {
+            $returnArray['caption'] = $this->getCaption();
         }
 
         return $returnArray;

--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -196,7 +196,7 @@ class ClientTest extends VonageTestCase
     public function testCanSendMMSvCard(): void
     {
         $vCardUrl = 'https://github.com/nuovo/vCard-parser/blob/master/Example.vcf';
-        $vCardObject = new VCardObject($vCardUrl);
+        $vCardObject = new VCardObject($vCardUrl, 'this is a picture');
 
         $payload = [
             'to' => '447700900000',
@@ -398,7 +398,8 @@ class ClientTest extends VonageTestCase
     {
         $fileObject = new FileObject(
             'https://file-examples.com/wp-content/uploads/2017/04/file_example_MP4_480_1_5MG.mp4',
-            'some file'
+            'some file',
+            'reticulating splines'
         );
 
         $payload = [
@@ -899,25 +900,35 @@ class ClientTest extends VonageTestCase
             'to' => '447700900000',
             'from' => '16105551212',
             'video' => $videoObject,
-            'thumb' => 'https://file-examples.com/wp-content/uploads/2017/04/preview.jpg'
+            'thumb' => 'https://file-examples.com/wp-content/uploads/2017/04/preview.jpg',
+            'duration' => '30',
+            'file_size' => '5'
         ];
 
         $message = new ViberVideo(
             $payload['to'],
             $payload['from'],
             $payload['thumb'],
-            $payload['video']
+            $payload['video'],
+            $payload['duration'],
+            $payload['file_size']
         );
 
         $videoMatch = $videoObject->toArray();
         $videoMatch['thumb_url'] = $payload['thumb'];
 
-        $this->vonageClient->send(Argument::that(function (Request $request) use ($payload, $videoMatch) {
+        $serviceObject = [
+            'duration' => $payload['duration'],
+            'file_size' => $payload['file_size']
+        ];
+
+        $this->vonageClient->send(Argument::that(function (Request $request) use ($payload, $videoMatch, $serviceObject) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
             $this->assertRequestJsonBodyContains('from', $payload['from'], $request);
             $this->assertRequestJsonBodyContains('video', $videoMatch, $request);
             $this->assertRequestJsonBodyContains('channel', 'viber_service', $request);
             $this->assertRequestJsonBodyContains('message_type', 'video', $request);
+            $this->assertRequestJsonBodyContains('viber_service', $serviceObject, $request);
 
             $this->assertEquals('POST', $request->getMethod());
 

--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -122,6 +122,49 @@ class ClientTest extends VonageTestCase
         $this->assertArrayHasKey('message_uuid', $result);
     }
 
+    public function testCanSendSMSWithOptionalFields(): void
+    {
+        $payload = [
+            'to' => '447700900000',
+            'from' => '16105551212',
+            'text' => 'Reticulating Splines',
+            'encoding_type' => 'auto',
+            'content_id' => '1107457532145798767',
+            'entity_id' => '1101456324675322134',
+            'webhook_url' => 'https://example.com/status',
+            'webhook_version' => 'v1',
+            'ttl' => 300
+        ];
+
+        $message = new SMSText($payload['to'], $payload['from'], $payload['text']);
+        $message->setEncodingType($payload['encoding_type']);
+        $message->setTtl($payload['ttl']);
+        $message->setContentId($payload['content_id']);
+        $message->setEntityId($payload['entity_id']);
+        $message->setWebhookUrl($payload['webhook_url']);
+        $message->setWebhookVersion($payload['webhook_version']);
+
+        $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
+            $this->assertRequestJsonBodyContains('ttl', $payload['ttl'], $request);
+            $this->assertRequestJsonBodyContains('webhook_url', $payload['webhook_url'], $request);
+            $this->assertRequestJsonBodyContains('webhook_version', $payload['webhook_version'], $request);
+            $smsObject = [
+                'encoding_type' => $payload['encoding_type'],
+                'content_id' => $payload['content_id'],
+                'entity_id' => $payload['entity_id']
+            ];
+
+            $this->assertRequestJsonBodyContains('sms', $smsObject, $request);
+
+            $this->assertEquals('POST', $request->getMethod());
+
+            return true;
+        }))->willReturn($this->getResponse('sms-success', 202));
+        $result = $this->messageClient->send($message);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('message_uuid', $result);
+    }
+
     public function testCanSendMMSImage(): void
     {
         $imageUrl = 'https://picsum.photos/200/300';


### PR DESCRIPTION
This PR provides parity with new Messages API features.

## Description
`webhook_url` and `webhook_version` have been added to all Messages API Objects
`sms` property added to outbound SMS text objects, containing `encoding_type`, `content_id`, `entity_id` and `ttl`
MMS vCard now has `caption`
WhatsApp File object now has `name`

Fixed the Viber Video object which was missing the `viber_service` object, but now has mandatory `duration` and `file_size` keys

## Motivation and Context
Parity with Vonage APIs

## How Has This Been Tested?
Existing tests have been modified

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
