### PR TITLE
Fix insight to return data when it is chargeable

### DIFF
--- a/src/Insights/Client.php
+++ b/src/Insights/Client.php
@@ -14,19 +14,21 @@ namespace Vonage\Insights;
 use Psr\Http\Client\ClientExceptionInterface;
 use Vonage\Client\APIClient;
 use Vonage\Client\APIResource;
-use Vonage\Client\ClientAwareInterface;
-use Vonage\Client\ClientAwareTrait;
 use Vonage\Client\Exception as ClientException;
+use Vonage\Client\Exception\Exception;
+use Vonage\Client\Exception\Request;
+use Vonage\Client\Exception\Server;
 use Vonage\Entity\Filter\KeyValueFilter;
+use Vonage\Entity\IterableAPICollection;
 use Vonage\Numbers\Number;
-
-use function is_null;
 
 /**
  * Class Client
  */
 class Client implements APIClient
 {
+    protected array $chargeableCodes = [0, 43, 44, 45];
+
     public function __construct(protected ?APIResource $api = null)
     {
     }
@@ -39,10 +41,11 @@ class Client implements APIClient
     /**
      * @param $number
      *
+     * @return Basic
      * @throws ClientExceptionInterface
-     * @throws ClientException\Exception
-     * @throws ClientException\Request
-     * @throws ClientException\Server
+     * @throws Exception
+     * @throws Request
+     * @throws Server
      */
     public function basic($number): Basic
     {
@@ -56,10 +59,11 @@ class Client implements APIClient
     /**
      * @param $number
      *
+     * @return StandardCnam
      * @throws ClientExceptionInterface
-     * @throws ClientException\Exception
-     * @throws ClientException\Request
-     * @throws ClientException\Server
+     * @throws Exception
+     * @throws Request
+     * @throws Server
      */
     public function standardCNam($number): StandardCnam
     {
@@ -72,10 +76,11 @@ class Client implements APIClient
     /**
      * @param $number
      *
+     * @return AdvancedCnam
      * @throws ClientExceptionInterface
-     * @throws ClientException\Exception
-     * @throws ClientException\Request
-     * @throws ClientException\Server
+     * @throws Exception
+     * @throws Request
+     * @throws Server
      */
     public function advancedCnam($number): AdvancedCnam
     {
@@ -146,6 +151,9 @@ class Client implements APIClient
     {
         $api = $this->getApiResource();
         $api->setBaseUri($path);
+        $collectionPrototype = new IterableAPICollection();
+        $collectionPrototype->setHasPagination(false);
+        $api->setCollectionPrototype($collectionPrototype);
 
         if ($number instanceof Number) {
             $number = $number->getMsisdn();
@@ -156,7 +164,7 @@ class Client implements APIClient
         $data = $result->getPageData();
 
         // check the status field in response (HTTP status is 200 even for errors)
-        if ((int)$data['status'] !== 0) {
+        if (! in_array((int)$data['status'], $this->chargeableCodes, true)) {
             throw $this->getNIException($data);
         }
 

--- a/test/Insights/AdvancedTest.php
+++ b/test/Insights/AdvancedTest.php
@@ -11,11 +11,41 @@ declare(strict_types=1);
 
 namespace VonageTest\Insights;
 
+use Laminas\Diactoros\Response;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Vonage\Client;
+use Vonage\Client\APIResource;
+use Vonage\Client\Credentials\Handler\BasicQueryHandler;
+use Vonage\Client\Exception\Request;
 use VonageTest\VonageTestCase;
 use Vonage\Insights\Advanced;
+use Vonage\Insights\Client as InsightClient;
 
 class AdvancedTest extends VonageTestCase
 {
+    public InsightClient $insightClient;
+    public Client|ObjectProphecy $vonageClient;
+    public APIResource $api;
+
+    public function setUp(): void
+    {
+        $this->vonageClient = $this->prophesize(Client::class);
+        $this->vonageClient->getRestUrl()->willReturn('https://api.nexmo.com');
+        $this->vonageClient->getCredentials()->willReturn(
+            new Client\Credentials\Container(
+                new Client\Credentials\Basic('abc', 'def'),
+            )
+        );
+
+        $this->api = (new APIResource())
+            ->setClient($this->vonageClient->reveal())
+            ->setIsHAL(false)
+            ->setAuthHandler(new BasicQueryHandler())
+            ->setBaseUrl('https://api.nexmo.com/ni/advanced');
+
+        $this->insightClient = new InsightClient($this->api);
+    }
     /**
      * @dataProvider advancedTestProvider
      *
@@ -26,6 +56,42 @@ class AdvancedTest extends VonageTestCase
     {
         $this->assertEquals($inputData['valid_number'], $advanced->getValidNumber());
         $this->assertEquals($inputData['reachable'], $advanced->getReachable());
+    }
+
+    /**
+     * @dataProvider advancedExceptionResponseProvider
+     * @param $responseName
+     * @param $expectException
+     *
+     * @return void
+     */
+    public function testExceptionWhenNotChargeable($responseName, $expectException): void
+    {
+        if ($expectException) {
+            $this->expectException(Request::class);
+        }
+
+        $this->vonageClient->send(Argument::that(function (\Laminas\Diactoros\Request $request) use ($responseName) {
+            $uri = $request->getUri();
+            $uriString = $uri->__toString();
+            $this->assertEquals('https://api.nexmo.com/ni/advanced/ni/advanced/json?number=12345&api_key=abc&api_secret=def', $uriString);
+            return true;
+        }))->willReturn($this->getResponse($responseName, 200));
+
+        $response = $this->insightClient->advanced('12345');
+        $this->assertInstanceOf(Advanced::class, $response);
+    }
+
+    public function advancedExceptionResponseProvider(): array
+    {
+        return [
+            ['advanced', false],
+            ['advanced3', true],
+            ['advanced4', true],
+            ['advanced43', false],
+            ['advanced44', false],
+            ['advanced45', false]
+        ];
     }
 
     public function advancedTestProvider(): array
@@ -42,5 +108,13 @@ class AdvancedTest extends VonageTestCase
         $r['standard-1'] = [$advanced1, $input1];
 
         return $r;
+    }
+
+    /**
+     * This method gets the fixtures and wraps them in a Response object to mock the API
+     */
+    protected function getResponse(string $identifier, int $status = 200): Response
+    {
+        return new Response(fopen(__DIR__ . '/responses/' . $identifier . '.json', 'rb'), $status);
     }
 }

--- a/test/Insights/responses/advanced3.json
+++ b/test/Insights/responses/advanced3.json
@@ -1,0 +1,4 @@
+{
+  "status": 3,
+  "status_message": "Your request is incomplete and missing some mandatory parameters"
+}

--- a/test/Insights/responses/advanced4.json
+++ b/test/Insights/responses/advanced4.json
@@ -1,0 +1,4 @@
+{
+  "status": 4,
+  "status_message": "Invalid credentials"
+}

--- a/test/Insights/responses/advanced43.json
+++ b/test/Insights/responses/advanced43.json
@@ -1,0 +1,32 @@
+{
+  "status": 43,
+  "status_message": "Lookup Handler unable to handle request",
+  "lookup_outcome": 1,
+  "lookup_outcome_message": "Partial success - some fields populated",
+  "request_id": "XXc89636-3714-42be-a731-9d8f52d7baXX",
+  "international_format_number": "18104967XXX",
+  "national_format_number": "(XXX) 496-7360",
+  "country_code": "US",
+  "country_code_iso3": "USA",
+  "country_name": "United States of America",
+  "country_prefix": "1",
+  "request_price": "0.03000000",
+  "remaining_balance": "98.24739334",
+  "current_carrier": {
+    "network_code": "US-FIXED",
+    "name": "United States of America Landline",
+    "country": "US",
+    "network_type": "landline"
+  },
+  "original_carrier": {
+    "network_code": "US-FIXED",
+    "name": "United States of America Landline",
+    "country": "US",
+    "network_type": "landline"
+  },
+  "valid_number": "valid",
+  "reachable": "unknown",
+  "ported": "unknown",
+  "roaming": "unknown",
+  "ip_warnings": "unknown"
+}

--- a/test/Insights/responses/advanced44.json
+++ b/test/Insights/responses/advanced44.json
@@ -1,0 +1,32 @@
+{
+  "status": 43,
+  "status_message": "Lookup Handler unable to handle request",
+  "lookup_outcome": 1,
+  "lookup_outcome_message": "Partial success - some fields populated",
+  "request_id": "XXc89636-3714-42be-a731-9d8f52d7baXX",
+  "international_format_number": "18104967XXX",
+  "national_format_number": "(XXX) 496-7360",
+  "country_code": "US",
+  "country_code_iso3": "USA",
+  "country_name": "United States of America",
+  "country_prefix": "1",
+  "request_price": "0.03000000",
+  "remaining_balance": "98.24739334",
+  "current_carrier": {
+    "network_code": "US-FIXED",
+    "name": "United States of America Landline",
+    "country": "US",
+    "network_type": "landline"
+  },
+  "original_carrier": {
+    "network_code": "US-FIXED",
+    "name": "United States of America Landline",
+    "country": "US",
+    "network_type": "landline"
+  },
+  "valid_number": "valid",
+  "reachable": "unknown",
+  "ported": "unknown",
+  "roaming": "unknown",
+  "ip_warnings": "unknown"
+}

--- a/test/Insights/responses/advanced45.json
+++ b/test/Insights/responses/advanced45.json
@@ -1,0 +1,32 @@
+{
+  "status": 43,
+  "status_message": "Lookup Handler unable to handle request",
+  "lookup_outcome": 1,
+  "lookup_outcome_message": "Partial success - some fields populated",
+  "request_id": "XXc89636-3714-42be-a731-9d8f52d7baXX",
+  "international_format_number": "18104967XXX",
+  "national_format_number": "(XXX) 496-7360",
+  "country_code": "US",
+  "country_code_iso3": "USA",
+  "country_name": "United States of America",
+  "country_prefix": "1",
+  "request_price": "0.03000000",
+  "remaining_balance": "98.24739334",
+  "current_carrier": {
+    "network_code": "US-FIXED",
+    "name": "United States of America Landline",
+    "country": "US",
+    "network_type": "landline"
+  },
+  "original_carrier": {
+    "network_code": "US-FIXED",
+    "name": "United States of America Landline",
+    "country": "US",
+    "network_type": "landline"
+  },
+  "valid_number": "valid",
+  "reachable": "unknown",
+  "ported": "unknown",
+  "roaming": "unknown",
+  "ip_warnings": "unknown"
+}


### PR DESCRIPTION
Number Insight API Handling currently throws exceptions when it shouldn't.

## Description
Due to the design of NIv1, 43, 44 and 45 status codes are chargeable and therefore the client should return the partial data that has been returned.

## Motivation and Context
Arose from #463 

## How Has This Been Tested?
Complete tests were not available for NI. I have added suitable API call mocks.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
