### PR TITLE
Make Event::getConversationUuid() return type nullable

### DIFF
--- a/src/Voice/Webhook/Event.php
+++ b/src/Voice/Webhook/Event.php
@@ -131,7 +131,7 @@ class Event
         $this->detail = $event['detail'] ?? null;
     }
 
-    public function getConversationUuid(): string
+    public function getConversationUuid(): ?string
     {
         return $this->conversationUuid;
     }


### PR DESCRIPTION
## Description
We spotted a webhook with `null` in the `conversation_uuid` field.

```json
{
    "conversation_uuid": null,
    "direction": "inbound",
    "duration": "0",
    "from": "*filtered*",
    "headers": [],
    "network": "20822",
    "price": "0.00000000",
    "rate": "0.00820000",
    "start_time": null,
    "status": "completed",
    "timestamp": "2024-02-12T13:25:35.241Z",
    "to": "*filtered*",
    "uuid": "835b549816baf1f8ce18e1088fb1b95a"
}
```

## Motivation and Context
We need to fix the type error.

## How Has This Been Tested?
In production.

## Example Output or Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
