### PR TITLE
Fix from is now mandatory for WA verify2 (WABA)

### DIFF
--- a/src/Verify2/Request/WhatsAppRequest.php
+++ b/src/Verify2/Request/WhatsAppRequest.php
@@ -10,14 +10,14 @@ class WhatsAppRequest extends BaseVerifyRequest
     public function __construct(
         protected string $to,
         protected string $brand,
-        protected ?string $from = null,
+        protected string $from,
         protected ?VerificationLocale $locale = null,
     ) {
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }
 
-        $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_WHATSAPP, $to);
+        $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_WHATSAPP, $to, $from);
 
         $this->addWorkflow($workflow);
     }

--- a/test/Verify2/ClientTest.php
+++ b/test/Verify2/ClientTest.php
@@ -255,11 +255,12 @@ class ClientTest extends VonageTestCase
     {
         $payload = [
             'to' => '07785254785',
+            'from' => '07785254785',
             'client_ref' => 'my-verification',
             'brand' => 'my-brand',
         ];
 
-        $whatsAppVerification = new WhatsAppRequest($payload['to'], $payload['brand']);
+        $whatsAppVerification = new WhatsAppRequest($payload['to'], $payload['brand'], $payload['from']);
         $whatsAppVerification->setClientRef($payload['client_ref']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
@@ -269,6 +270,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('code_length', 4, $request);
             $this->assertRequestJsonBodyContains('brand', $payload['brand'], $request);
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request, true);
+            $this->assertRequestJsonBodyContains('from', $payload['from'], $request, true);
             $this->assertRequestJsonBodyContains('channel', 'whatsapp', $request, true);
             $this->assertEquals('POST', $request->getMethod());
 


### PR DESCRIPTION
`from` parameter is now mandatory when using WhatsApp for Verify v2

## Description
Previously, a shared Vonage WABA was used. This is no longer the case.

## Motivation and Context
I am counting this as a patch, but it is technically a change that is backwards breaking. This is, however, at the API level and therefore it is the API versioning that should be adjusted. A major release at this point is likely to cause more difficulties to customers than a patch to make sure the SDK has parity with the API.

## How Has This Been Tested?
Tests adjusted

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
