### PR TITLE
Add from validation on request

### DIFF
--- a/src/Verify2/VerifyObjects/VerificationWorkflow.php
+++ b/src/Verify2/VerifyObjects/VerificationWorkflow.php
@@ -31,6 +31,10 @@ class VerificationWorkflow implements ArrayHydrateInterface
         if (! in_array($channel, $this->allowedWorkflows, true)) {
             throw new \InvalidArgumentException($this->channel . ' is not a valid workflow');
         }
+
+        if ($this->isInvalidFromValue($this->from)) {
+            throw new \InvalidArgumentException($this->from . ' is not a valid from value');
+        }
     }
 
     public function getChannel(): string
@@ -111,5 +115,31 @@ class VerificationWorkflow implements ArrayHydrateInterface
         $this->customKeys = $customKeys;
 
         return $this;
+    }
+
+    protected function isInvalidFromValue(string $fromValue): bool
+    {
+        if ($fromValue === '') {
+            // This is a null value and doesn't need to be validated
+            return false;
+        }
+
+        if (($this->channel === self::WORKFLOW_EMAIL) && filter_var($fromValue, FILTER_VALIDATE_EMAIL)) {
+            return false;
+        }
+
+        if (is_numeric($fromValue)) {
+            $length = strlen($fromValue);
+
+            return $length < 11 || $length > 15;
+        }
+
+        if (ctype_alnum($fromValue)) {
+            $length = strlen($fromValue);
+
+            return $length < 3 || $length > 11;
+        }
+
+        return true;
     }
 }

--- a/test/Verify2/VerifyObjects/VerificationWorkflowTest.php
+++ b/test/Verify2/VerifyObjects/VerificationWorkflowTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Verify2\VerifyObjects;
+
+use InvalidArgumentException;
+use Vonage\Verify2\VerifyObjects\VerificationWorkflow;
+use VonageTest\VonageTestCase;
+
+class VerificationWorkflowTest extends VonageTestCase
+{
+    public function testWillTakeValidNumericFromValue(): void
+    {
+        $workflow = new VerificationWorkflow(
+            VerificationWorkflow::WORKFLOW_SMS,
+            'xxx',
+            '44773666552'
+        );
+
+        $this->assertInstanceOf(VerificationWorkflow::class, $workflow);
+    }
+
+    public function testWillTakeValidAlphaFromValue(): void
+    {
+        $workflow = new VerificationWorkflow(
+            VerificationWorkflow::WORKFLOW_SMS,
+            'xxx',
+            'ACMECOMPANY'
+        );
+
+        $this->assertInstanceOf(VerificationWorkflow::class, $workflow);
+    }
+
+    public function testWillThrowErrorOnInvalidNumericFromValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $workflow = new VerificationWorkflow(
+            VerificationWorkflow::WORKFLOW_SMS,
+            'xxx',
+            '3459568445'
+        );
+    }
+
+    public function testWillThrowErrorOnInvalidAlphaFromValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $workflow = new VerificationWorkflow(
+            VerificationWorkflow::WORKFLOW_SMS,
+            'xxx',
+            'MYAWESOMECOMPANYISTOOBIG'
+        );
+    }
+}


### PR DESCRIPTION
This PR adds validation to the Verify2 client to stop invalid `from` values.

## Description
These are changes in line with the API spec

## Motivation and Context
Evolution of Vonage SDKs

## How Has This Been Tested?
Validation tests added

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
