### PR TITLE
Add new messages fields

### DIFF
--- a/src/Messages/Channel/MMS/MMSAudio.php
+++ b/src/Messages/Channel/MMS/MMSAudio.php
@@ -4,9 +4,12 @@ namespace Vonage\Messages\Channel\MMS;
 
 use Vonage\Messages\MessageObjects\AudioObject;
 use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\MessageTraits\TtlTrait;
 
 class MMSAudio extends BaseMessage
 {
+    use TtlTrait;
+
     protected string $channel = 'mms';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_AUDIO;
 
@@ -23,6 +26,10 @@ class MMSAudio extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['audio'] = $this->audioObject->toArray();
+
+        if (!is_null($this->ttl)) {
+            $returnArray['ttl'] = $this->ttl;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/MMS/MMSImage.php
+++ b/src/Messages/Channel/MMS/MMSImage.php
@@ -4,9 +4,12 @@ namespace Vonage\Messages\Channel\MMS;
 
 use Vonage\Messages\MessageObjects\ImageObject;
 use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\MessageTraits\TtlTrait;
 
 class MMSImage extends BaseMessage
 {
+    use TtlTrait;
+
     protected string $channel = 'mms';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_IMAGE;
 
@@ -23,6 +26,10 @@ class MMSImage extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['image'] = $this->image->toArray();
+
+        if (!is_null($this->ttl)) {
+            $returnArray['ttl'] = $this->ttl;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/MMS/MMSVideo.php
+++ b/src/Messages/Channel/MMS/MMSVideo.php
@@ -5,9 +5,12 @@ namespace Vonage\Messages\Channel\MMS;
 use Vonage\Messages\MessageObjects\AudioObject;
 use Vonage\Messages\MessageObjects\VideoObject;
 use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\MessageTraits\TtlTrait;
 
 class MMSVideo extends BaseMessage
 {
+    use TtlTrait;
+
     protected string $channel = 'mms';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VIDEO;
 
@@ -24,6 +27,10 @@ class MMSVideo extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['video'] = $this->videoObject->toArray();
+
+        if (!is_null($this->ttl)) {
+            $returnArray['ttl'] = $this->ttl;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/MMS/MMSvCard.php
+++ b/src/Messages/Channel/MMS/MMSvCard.php
@@ -4,9 +4,12 @@ namespace Vonage\Messages\Channel\MMS;
 
 use Vonage\Messages\MessageObjects\VCardObject;
 use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\MessageTraits\TtlTrait;
 
 class MMSvCard extends BaseMessage
 {
+    use TtlTrait;
+
     protected string $channel = 'mms';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VCARD;
 
@@ -23,6 +26,10 @@ class MMSvCard extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['vcard'] = $this->vCard->toArray();
+
+        if (!is_null($this->ttl)) {
+            $returnArray['ttl'] = $this->ttl;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/WhatsApp/WhatsAppAudio.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppAudio.php
@@ -4,9 +4,12 @@ namespace Vonage\Messages\Channel\WhatsApp;
 
 use Vonage\Messages\MessageObjects\AudioObject;
 use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\MessageTraits\ContextTrait;
 
 class WhatsAppAudio extends BaseMessage
 {
+    use ContextTrait;
+
     protected string $channel = 'whatsapp';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_AUDIO;
 
@@ -23,6 +26,10 @@ class WhatsAppAudio extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['audio'] = $this->audioObject->toArray();
+
+        if (!is_null($this->context)) {
+            $returnArray['context'] = $this->context;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/WhatsApp/WhatsAppCustom.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppCustom.php
@@ -3,9 +3,12 @@
 namespace Vonage\Messages\Channel\WhatsApp;
 
 use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\MessageTraits\ContextTrait;
 
 class WhatsAppCustom extends BaseMessage
 {
+    use ContextTrait;
+
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_CUSTOM;
     protected string $channel = 'whatsapp';
 
@@ -32,6 +35,10 @@ class WhatsAppCustom extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['custom'] = $this->getCustom();
+
+        if (!is_null($this->context)) {
+            $returnArray['context'] = $this->context;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/WhatsApp/WhatsAppFile.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppFile.php
@@ -4,9 +4,12 @@ namespace Vonage\Messages\Channel\WhatsApp;
 
 use Vonage\Messages\MessageObjects\FileObject;
 use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\MessageTraits\ContextTrait;
 
 class WhatsAppFile extends BaseMessage
 {
+    use ContextTrait;
+
     protected string $channel = 'whatsapp';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_FILE;
 
@@ -23,6 +26,10 @@ class WhatsAppFile extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['file'] = $this->fileObject->toArray();
+
+        if (!is_null($this->context)) {
+            $returnArray['context'] = $this->context;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/WhatsApp/WhatsAppImage.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppImage.php
@@ -4,9 +4,12 @@ namespace Vonage\Messages\Channel\WhatsApp;
 
 use Vonage\Messages\MessageObjects\ImageObject;
 use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\MessageTraits\ContextTrait;
 
 class WhatsAppImage extends BaseMessage
 {
+    use ContextTrait;
+
     protected string $channel = 'whatsapp';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_IMAGE;
 
@@ -23,6 +26,10 @@ class WhatsAppImage extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['image'] = $this->image->toArray();
+
+        if (!is_null($this->context)) {
+            $returnArray['context'] = $this->context;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/WhatsApp/WhatsAppSticker.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppSticker.php
@@ -4,9 +4,12 @@ namespace Vonage\Messages\Channel\WhatsApp;
 
 use Vonage\Messages\Channel\BaseMessage;
 use Vonage\Messages\Channel\WhatsApp\MessageObjects\StickerObject;
+use Vonage\Messages\MessageTraits\ContextTrait;
 
 class WhatsAppSticker extends BaseMessage
 {
+    use ContextTrait;
+
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_STICKER;
     protected string $channel = 'whatsapp';
 
@@ -35,6 +38,10 @@ class WhatsAppSticker extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['sticker'] = $this->getSticker()->toArray();
+
+        if (!is_null($this->context)) {
+            $returnArray['context'] = $this->context;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/WhatsApp/WhatsAppTemplate.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppTemplate.php
@@ -5,9 +5,12 @@ namespace Vonage\Messages\Channel\WhatsApp;
 use Vonage\Messages\MessageObjects\FileObject;
 use Vonage\Messages\MessageObjects\TemplateObject;
 use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\MessageTraits\ContextTrait;
 
 class WhatsAppTemplate extends BaseMessage
 {
+    use ContextTrait;
+
     protected string $channel = 'whatsapp';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_TEMPLATE;
 
@@ -30,6 +33,10 @@ class WhatsAppTemplate extends BaseMessage
                 'locale' => $this->getLocale()
             ]
         ];
+
+        if (!is_null($this->context)) {
+            $returnArray['context'] = $this->context;
+        }
 
         return array_merge($this->getBaseMessageUniversalOutputArray(), $returnArray);
     }

--- a/src/Messages/Channel/WhatsApp/WhatsAppText.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppText.php
@@ -2,11 +2,13 @@
 
 namespace Vonage\Messages\Channel\WhatsApp;
 
+use Vonage\Messages\MessageTraits\ContextTrait;
 use Vonage\Messages\MessageTraits\TextTrait;
 use Vonage\Messages\Channel\BaseMessage;
 
 class WhatsAppText extends BaseMessage
 {
+    use ContextTrait;
     use TextTrait;
 
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_TEXT;
@@ -26,6 +28,10 @@ class WhatsAppText extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['text'] = $this->getText();
+
+        if (!is_null($this->context)) {
+            $returnArray['context'] = $this->context;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/Channel/WhatsApp/WhatsAppVideo.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppVideo.php
@@ -4,9 +4,12 @@ namespace Vonage\Messages\Channel\WhatsApp;
 
 use Vonage\Messages\MessageObjects\VideoObject;
 use Vonage\Messages\Channel\BaseMessage;
+use Vonage\Messages\MessageTraits\ContextTrait;
 
 class WhatsAppVideo extends BaseMessage
 {
+    use ContextTrait;
+
     protected string $channel = 'whatsapp';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VIDEO;
 
@@ -23,6 +26,10 @@ class WhatsAppVideo extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['video'] = $this->videoObject->toArray();
+
+        if (!is_null($this->context)) {
+            $returnArray['context'] = $this->context;
+        }
 
         return $returnArray;
     }

--- a/src/Messages/MessageTraits/ContextTrait.php
+++ b/src/Messages/MessageTraits/ContextTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Vonage\Messages\MessageTraits;
+
+trait ContextTrait
+{
+    private ?array $context;
+
+    public function getContext(): ?array
+    {
+        return $this->context;
+    }
+
+    public function setContext(?array $context): static
+    {
+        $this->context = $context;
+
+        return $this;
+    }
+}

--- a/src/Messages/MessageTraits/TtlTrait.php
+++ b/src/Messages/MessageTraits/TtlTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Vonage\Messages\MessageTraits;
+
+trait TtlTrait
+{
+    private ?int $ttl;
+
+    public function getTtl(): ?int
+    {
+        return $this->ttl;
+    }
+
+    public function setTTl(?int $ttl): static
+    {
+        $this->ttl = $ttl;
+
+        return $this;
+    }
+}

--- a/test/Client/Exception/Validation.php
+++ b/test/Client/Exception/Validation.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace VonageTest\Client\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Vonage\Client\Exception\Exception;
+
+class Validation extends TestCase
+{
+    public function testValidationException()
+    {
+        $message = 'Validation failed';
+        $code = 422;
+        $previous = new Exception('Previous exception');
+        $errors = [
+            'field1' => 'Error message 1',
+            'field2' => 'Error message 2'
+        ];
+
+        $exception = new Validation($message, $code, $previous, $errors);
+
+        // Assert the exception message
+        $this->assertEquals($message, $exception->getMessage());
+
+        // Assert the exception code
+        $this->assertEquals($code, $exception->getCode());
+
+        // Assert the previous exception
+        $this->assertSame($previous, $exception->getPrevious());
+
+        // Assert the validation errors
+        $this->assertEquals($errors, $exception->getValidationErrors());
+    }
+}

--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -169,6 +169,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new MMSImage($payload['to'], $payload['from'], $mmsImageObject);
+        $message->setTtl(400);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -176,6 +177,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('image', $payload['image']->toArray(), $request);
             $this->assertRequestJsonBodyContains('channel', 'mms', $request);
             $this->assertRequestJsonBodyContains('message_type', 'image', $request);
+            $this->assertRequestJsonBodyContains('ttl', 400, $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -197,6 +199,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new MMSvCard($payload['to'], $payload['from'], $vCardObject);
+        $message->setTtl(400);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -204,6 +207,8 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('vcard', $payload['vcard']->toArray(), $request);
             $this->assertRequestJsonBodyContains('channel', 'mms', $request);
             $this->assertRequestJsonBodyContains('message_type', 'vcard', $request);
+            $this->assertRequestJsonBodyContains('ttl', 400, $request);
+
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -227,6 +232,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new MMSAudio($payload['to'], $payload['from'], $audioObject);
+        $message->setTtl(400);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -234,6 +240,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('audio', $payload['audio']->toArray(), $request);
             $this->assertRequestJsonBodyContains('channel', 'mms', $request);
             $this->assertRequestJsonBodyContains('message_type', 'audio', $request);
+            $this->assertRequestJsonBodyContains('ttl', 400, $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -257,6 +264,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new MMSVideo($payload['to'], $payload['from'], $videoObject);
+        $message->setTtl(400);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -264,6 +272,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('video', $payload['video']->toArray(), $request);
             $this->assertRequestJsonBodyContains('channel', 'mms', $request);
             $this->assertRequestJsonBodyContains('message_type', 'video', $request);
+            $this->assertRequestJsonBodyContains('ttl', 400, $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -282,6 +291,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new WhatsAppText($payload['to'], $payload['from'], $payload['text']);
+        $message->setContext(['message_uuid' => 'a1b2c3d4a1b2c3d4']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -289,6 +299,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('text', $payload['text'], $request);
             $this->assertRequestJsonBodyContains('channel', 'whatsapp', $request);
             $this->assertRequestJsonBodyContains('message_type', 'text', $request);
+            $this->assertRequestJsonBodyContains('context', ['message_uuid' => 'a1b2c3d4a1b2c3d4'], $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -310,6 +321,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new WhatsAppImage($payload['to'], $payload['from'], $whatsAppImageObject);
+        $message->setContext(['message_uuid' => 'a1b2c3d4a1b2c3d4']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -317,6 +329,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('image', $payload['image']->toArray(), $request);
             $this->assertRequestJsonBodyContains('channel', 'whatsapp', $request);
             $this->assertRequestJsonBodyContains('message_type', 'image', $request);
+            $this->assertRequestJsonBodyContains('context', ['message_uuid' => 'a1b2c3d4a1b2c3d4'], $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -340,6 +353,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new WhatsAppAudio($payload['to'], $payload['from'], $audioObject);
+        $message->setContext(['message_uuid' => 'a1b2c3d4a1b2c3d4']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -347,6 +361,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('audio', $payload['audio']->toArray(), $request);
             $this->assertRequestJsonBodyContains('channel', 'whatsapp', $request);
             $this->assertRequestJsonBodyContains('message_type', 'audio', $request);
+            $this->assertRequestJsonBodyContains('context', ['message_uuid' => 'a1b2c3d4a1b2c3d4'], $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -370,6 +385,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new WhatsAppVideo($payload['to'], $payload['from'], $videoObject);
+        $message->setContext(['message_uuid' => 'a1b2c3d4a1b2c3d4']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -377,6 +393,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('video', $payload['video']->toArray(), $request);
             $this->assertRequestJsonBodyContains('channel', 'whatsapp', $request);
             $this->assertRequestJsonBodyContains('message_type', 'video', $request);
+            $this->assertRequestJsonBodyContains('context', ['message_uuid' => 'a1b2c3d4a1b2c3d4'], $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -401,6 +418,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new WhatsAppFile($payload['to'], $payload['from'], $fileObject);
+        $message->setContext(['message_uuid' => 'a1b2c3d4a1b2c3d4']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -408,6 +426,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('file', $payload['file']->toArray(), $request);
             $this->assertRequestJsonBodyContains('channel', 'whatsapp', $request);
             $this->assertRequestJsonBodyContains('message_type', 'file', $request);
+            $this->assertRequestJsonBodyContains('context', ['message_uuid' => 'a1b2c3d4a1b2c3d4'], $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -431,6 +450,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new WhatsAppTemplate($payload['to'], $payload['from'], $templateObject, 'en_GB');
+        $message->setContext(['message_uuid' => 'a1b2c3d4a1b2c3d4']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -438,6 +458,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('template', $payload['template']->toArray(), $request);
             $this->assertRequestJsonBodyContains('channel', 'whatsapp', $request);
             $this->assertRequestJsonBodyContains('message_type', 'template', $request);
+            $this->assertRequestJsonBodyContains('context', ['message_uuid' => 'a1b2c3d4a1b2c3d4'], $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -468,12 +489,14 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new WhatsAppSticker($payload['to'], $payload['from'], $stickerObject);
+        $message->setContext(['message_uuid' => 'a1b2c3d4a1b2c3d4']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload, $type) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
             $this->assertRequestJsonBodyContains('from', $payload['from'], $request);
             $this->assertRequestJsonBodyContains('channel', 'whatsapp', $request);
             $this->assertRequestJsonBodyContains('message_type', BaseMessage::MESSAGES_SUBTYPE_STICKER, $request);
+            $this->assertRequestJsonBodyContains('context', ['message_uuid' => 'a1b2c3d4a1b2c3d4'], $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;
@@ -495,6 +518,7 @@ class ClientTest extends VonageTestCase
         ];
 
         $message = new WhatsAppCustom($payload['to'], $payload['from'], $payload['custom']);
+        $message->setContext(['message_uuid' => 'a1b2c3d4a1b2c3d4']);
 
         $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
             $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
@@ -502,6 +526,7 @@ class ClientTest extends VonageTestCase
             $this->assertRequestJsonBodyContains('custom', $payload['custom'], $request);
             $this->assertRequestJsonBodyContains('channel', 'whatsapp', $request);
             $this->assertRequestJsonBodyContains('message_type', 'custom', $request);
+            $this->assertRequestJsonBodyContains('context', ['message_uuid' => 'a1b2c3d4a1b2c3d4'], $request);
             $this->assertEquals('POST', $request->getMethod());
 
             return true;


### PR DESCRIPTION
This PR adds new available fields as added by the API Spec

## Description
You can now set a TTL (Time-to-live) on MMS Objects. This is done with $message->setTtl(300);
Please [see the API spec](https://developer.vonage.com/en/api/messages-olympus?source=messages) for more information.

## Motivation and Context
Evolution of Vonage products.

## How Has This Been Tested?
Tests have been updated to check the output sent to the API

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
