### PR TITLE
Min timeout for Verify requests is now 15

### DIFF
--- a/src/Verify2/Request/BaseVerifyRequest.php
+++ b/src/Verify2/Request/BaseVerifyRequest.php
@@ -7,7 +7,7 @@ use Vonage\Verify2\VerifyObjects\VerificationWorkflow;
 
 abstract class BaseVerifyRequest implements RequestInterface
 {
-    private const TIMEOUT_MIN = 60;
+    private const TIMEOUT_MIN = 15;
     private const TIMEOUT_MAX = 900;
     private const LENGTH_MIN = 4;
     private const LENGTH_MAX = 10;

--- a/test/Verify2/ClientTest.php
+++ b/test/Verify2/ClientTest.php
@@ -744,7 +744,7 @@ class ClientTest extends VonageTestCase
         return [
             [60, true],
             [900, true],
-            [59, false],
+            [13, false],
             [564, true],
             [921, false],
         ];

--- a/test/Verify2/Request/BaseVerifyRequestTest.php
+++ b/test/Verify2/Request/BaseVerifyRequestTest.php
@@ -30,7 +30,7 @@ class BaseVerifyRequestTest extends TestCase
         $this->assertEquals(120, $request->getTimeout());
 
         $this->expectException(\OutOfBoundsException::class);
-        $request->setTimeout(50);
+        $request->setTimeout(14);
     }
 
     public function testGetSetCode(): void


### PR DESCRIPTION
This PR changes the minimum timeout for Verify to be 15 seconds.

## Description
See tests for ranges permitted.

## Motivation and Context
API change that is backwards compatible.

## How Has This Been Tested?
Test suite updated.
## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
