### PR TITLE
Add validation for brand

### DIFF
--- a/src/Verify2/Request/BaseVerifyRequest.php
+++ b/src/Verify2/Request/BaseVerifyRequest.php
@@ -170,4 +170,13 @@ abstract class BaseVerifyRequest implements RequestInterface
 
         return $returnArray;
     }
+
+    public static function isBrandValid(string $brand): bool
+    {
+        if (!strlen($brand) < 16) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Verify2/Request/EmailRequest.php
+++ b/src/Verify2/Request/EmailRequest.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Verify2\Request;
 
+use InvalidArgumentException;
 use Vonage\Verify2\VerifyObjects\VerificationLocale;
 use Vonage\Verify2\VerifyObjects\VerificationWorkflow;
 
@@ -13,6 +14,10 @@ class EmailRequest extends BaseVerifyRequest
         protected string $from,
         protected ?VerificationLocale $locale = null,
     ) {
+        if (!self::isBrandValid($this->brand)) {
+            throw new InvalidArgumentException('The brand name cannot be longer than 16 characters.');
+        }
+
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }

--- a/src/Verify2/Request/SMSRequest.php
+++ b/src/Verify2/Request/SMSRequest.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Verify2\Request;
 
+use InvalidArgumentException;
 use Vonage\Verify2\VerifyObjects\VerificationLocale;
 use Vonage\Verify2\VerifyObjects\VerificationWorkflow;
 
@@ -15,6 +16,10 @@ class SMSRequest extends BaseVerifyRequest
         protected string $entityId = '',
         protected string $contentId = ''
     ) {
+        if (!self::isBrandValid($this->brand)) {
+            throw new InvalidArgumentException('The brand name cannot be longer than 16 characters.');
+        }
+
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }

--- a/src/Verify2/Request/SilentAuthRequest.php
+++ b/src/Verify2/Request/SilentAuthRequest.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Verify2\Request;
 
+use InvalidArgumentException;
 use Vonage\Verify2\VerifyObjects\VerificationWorkflow;
 
 class SilentAuthRequest extends BaseVerifyRequest
@@ -11,6 +12,10 @@ class SilentAuthRequest extends BaseVerifyRequest
         protected string $brand,
         protected ?string $redirectUrl = null
     ) {
+        if (!self::isBrandValid($this->brand)) {
+            throw new InvalidArgumentException('The brand name cannot be longer than 16 characters.');
+        }
+
         $workflow = new VerificationWorkflow(VerificationWorkflow::WORKFLOW_SILENT_AUTH, $to);
 
         if ($this->redirectUrl) {

--- a/src/Verify2/Request/VoiceRequest.php
+++ b/src/Verify2/Request/VoiceRequest.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Verify2\Request;
 
+use InvalidArgumentException;
 use Vonage\Verify2\VerifyObjects\VerificationLocale;
 use Vonage\Verify2\VerifyObjects\VerificationWorkflow;
 
@@ -12,6 +13,10 @@ class VoiceRequest extends BaseVerifyRequest
         protected string $brand,
         protected ?VerificationLocale $locale = null,
     ) {
+        if (!self::isBrandValid($this->brand)) {
+            throw new InvalidArgumentException('The brand name cannot be longer than 16 characters.');
+        }
+
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }

--- a/src/Verify2/Request/WhatsAppInteractiveRequest.php
+++ b/src/Verify2/Request/WhatsAppInteractiveRequest.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Verify2\Request;
 
+use InvalidArgumentException;
 use Vonage\Verify2\VerifyObjects\VerificationLocale;
 use Vonage\Verify2\VerifyObjects\VerificationWorkflow;
 
@@ -12,6 +13,10 @@ class WhatsAppInteractiveRequest extends BaseVerifyRequest
         protected string $brand,
         protected ?VerificationLocale $locale = null
     ) {
+        if (!self::isBrandValid($this->brand)) {
+            throw new InvalidArgumentException('The brand name cannot be longer than 16 characters.');
+        }
+
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }

--- a/src/Verify2/Request/WhatsAppRequest.php
+++ b/src/Verify2/Request/WhatsAppRequest.php
@@ -2,6 +2,7 @@
 
 namespace Vonage\Verify2\Request;
 
+use InvalidArgumentException;
 use Vonage\Verify2\VerifyObjects\VerificationLocale;
 use Vonage\Verify2\VerifyObjects\VerificationWorkflow;
 
@@ -13,6 +14,10 @@ class WhatsAppRequest extends BaseVerifyRequest
         protected string $from,
         protected ?VerificationLocale $locale = null,
     ) {
+        if (!self::isBrandValid($this->brand)) {
+            throw new InvalidArgumentException('The brand name cannot be longer than 16 characters.');
+        }
+
         if (!$this->locale) {
             $this->locale = new VerificationLocale();
         }

--- a/test/Verify2/ClientTest.php
+++ b/test/Verify2/ClientTest.php
@@ -8,6 +8,7 @@ use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use Vonage\Messages\Channel\Messenger\InvalidCategoryException;
 use VonageTest\Traits\Psr7AssertionTrait;
 use Vonage\Client;
 use Vonage\Client\APIResource;
@@ -500,8 +501,7 @@ class ClientTest extends VonageTestCase
 
     public function testCannotSendWithoutBrand(): void
     {
-        $this->expectException(Client\Exception\Request::class);
-        $this->expectExceptionMessage('Invalid params: The value of one or more parameters is invalid. See https://www.developer.vonage.com/api-errors#invalid-params for more information');
+        $this->expectException(\InvalidArgumentException::class);
 
         $payload = [
             'to' => '07785254785',


### PR DESCRIPTION
This PR adds validation for the mandatory brand parameter in Verify

## Motivation and Context
This stops the API request from going out before being validated by Vonage servers.

## How Has This Been Tested?
Test amended

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
