### PR TITLE
Added validation for Silent Auth

### DIFF
--- a/src/Verify2/Request/SilentAuthRequest.php
+++ b/src/Verify2/Request/SilentAuthRequest.php
@@ -32,4 +32,15 @@ class SilentAuthRequest extends BaseVerifyRequest
             'workflow' => $this->getWorkflows()
         ];
     }
+
+    public static function isValidWorkflow(array $workflows): bool
+    {
+        $firstWorkflow = $workflows[0];
+
+        if ($firstWorkflow['channel'] == VerificationWorkflow::WORKFLOW_SILENT_AUTH) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/test/Verify2/Request/SilentAuthRequestTest.php
+++ b/test/Verify2/Request/SilentAuthRequestTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VonageTest\Verify2\Request;
+
+use PHPUnit\Framework\TestCase;
+use Vonage\Client;
+use Vonage\Verify2\Request\BaseVerifyRequest;
+use Vonage\Verify2\Request\SilentAuthRequest;
+use Vonage\Verify2\Request\SMSRequest;
+use Vonage\Verify2\VerifyObjects\VerificationLocale;
+use Vonage\Verify2\VerifyObjects\VerificationWorkflow;
+
+class SilentAuthRequestTest extends TestCase
+{
+    public function testIsValidSilentAuthRequest(): void
+    {
+        $silentAuthRequest = new SilentAuthRequest(
+            '077377775555',
+            'VONAGE',
+            'https://silent-auth.example'
+        );
+
+        $extraWorkflow = new VerificationWorkflow(
+            VerificationWorkflow::WORKFLOW_SMS,
+            '077377775555'
+        );
+
+        $silentAuthRequest->addWorkflow($extraWorkflow);
+
+        $client = new Client(new Client\Credentials\Basic('test', 'test2'));
+        $this->assertTrue($client->verify2()::isSilentAuthRequest($silentAuthRequest));
+        $this->assertTrue(SilentAuthRequest::isValidWorkflow($silentAuthRequest->getWorkflows()));
+    }
+
+    public function testIsInvalidSilentAuthRequest(): void
+    {
+        $request = new SMSRequest(
+            '077377775555',
+            'VONAGE',
+        );
+
+        $extraWorkflow = new VerificationWorkflow(
+            VerificationWorkflow::WORKFLOW_SILENT_AUTH,
+            '077377775555'
+        );
+
+        $request->addWorkflow($extraWorkflow);
+        $client = new Client(new Client\Credentials\Basic('test', 'test2'));
+
+        $this->assertTrue($client->verify2()::isSilentAuthRequest($request));
+        $this->assertFalse(SilentAuthRequest::isValidWorkflow($request->getWorkflows()));
+    }
+
+    public function testIsNotSilentAuthRequest(): void
+    {
+        $request = new SMSRequest(
+            '077377775555',
+            'VONAGE',
+        );
+
+        $extraWorkflow = new VerificationWorkflow(
+            VerificationWorkflow::WORKFLOW_EMAIL,
+            'jim@jim.com'
+        );
+
+        $request->addWorkflow($extraWorkflow);
+        $client = new Client(new Client\Credentials\Basic('test', 'test2'));
+
+        $this->assertFalse($client->verify2()::isSilentAuthRequest($request));
+        // No second test to see if the workflow is valid, why are you checking a workflow on a non SA request?
+    }
+}


### PR DESCRIPTION
This PR adds validation for Silent Authentication requests to stop the developer from being able to send invalid requests using the SDK

## Description
Two new methods have been used and implemented in the Verify2 client:
`isSilentAuthRequest()` - loops through the workflows to see if one of the channels used is Silent Auth. If it is, returns true. It doesn't matter if the request is not a `SilentAuthRequest::class` because that is just guidance for using the SDK. Users can stitch together whatever they want.
`isValidWorkflow()` checks that Silent Auth is the first channel. This should only be called if the request is a silent auth request.

## Motivation and Context
Stops developers from being charged before they hit the API.

## How Has This Been Tested?
Tests included for both of these new functions.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
