### PR TITLE
Fixes NCCO parsing to and from arrays

### DIFF
--- a/src/Voice/NCCO/Action/Input.php
+++ b/src/Voice/NCCO/Action/Input.php
@@ -84,6 +84,9 @@ class Input implements ActionInterface
         if (array_key_exists('dtmf', $data)) {
             $dtmf = $data['dtmf'];
             $action->setEnableDtmf(true);
+            if (is_object($dtmf)) {
+                $dtmf = (array)$dtmf;
+            }
 
             if (array_key_exists('timeOut', $dtmf)) {
                 $action->setDtmfTimeout((int)$dtmf['timeOut']);
@@ -103,6 +106,9 @@ class Input implements ActionInterface
         if (array_key_exists('speech', $data)) {
             $speech = $data['speech'];
             $action->setEnableSpeech(true);
+            if (is_object($speech)) {
+                $speech = (array)$speech;
+            }
 
             if (array_key_exists('uuid', $speech)) {
                 $action->setSpeechUUID($speech['uuid'][0]);

--- a/src/Voice/NCCO/Action/Notify.php
+++ b/src/Voice/NCCO/Action/Notify.php
@@ -21,6 +21,9 @@ class Notify implements ActionInterface
     public static function factory(array $payload, array $data): Notify
     {
         if (array_key_exists('eventUrl', $data)) {
+            if (is_array($data['eventUrl'])) {
+                $data['eventUrl'] = $data['eventUrl'][0];
+            }
             if (array_key_exists('eventMethod', $data)) {
                 $webhook = new Webhook($data['eventUrl'], $data['eventMethod']);
             } else {

--- a/src/Voice/NCCO/Action/Record.php
+++ b/src/Voice/NCCO/Action/Record.php
@@ -71,7 +71,9 @@ class Record implements ActionInterface
         }
 
         if (array_key_exists('channels', $data)) {
-            $action->setChannels($data['channels']);
+            $action->setChannels(
+                filter_var($data['channels'], FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE)
+            );
         }
 
         if (array_key_exists('endOnSilence', $data)) {
@@ -85,7 +87,9 @@ class Record implements ActionInterface
         }
 
         if (array_key_exists('timeOut', $data)) {
-            $action->setTimeout($data['timeOut']);
+            $action->setTimeout(
+                filter_var($data['timeOut'], FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE)
+            );
         }
 
         if (array_key_exists('beepStart', $data)) {
@@ -95,6 +99,9 @@ class Record implements ActionInterface
         }
 
         if (array_key_exists('eventUrl', $data)) {
+            if (is_array($data['eventUrl'])) {
+                $data['eventUrl'] = $data['eventUrl'][0];
+            }
             if (array_key_exists('eventMethod', $data)) {
                 $webhook = new Webhook($data['eventUrl'], $data['eventMethod']);
             } else {

--- a/src/Voice/NCCO/Action/Stream.php
+++ b/src/Voice/NCCO/Action/Stream.php
@@ -30,10 +30,13 @@ class Stream implements ActionInterface
     }
 
     /**
-     * @param array{streamUrl: string, bargeIn?: bool, level?: float, loop?: int, voiceName?: string} $data
+     * @param array{streamUrl: string|array, bargeIn?: bool, level?: float, loop?: int, voiceName?: string} $data
      */
-    public static function factory(string $streamUrl, array $data): Stream
+    public static function factory(string|array $streamUrl, array $data): Stream
     {
+        if (is_array($streamUrl)) {
+            $streamUrl = $streamUrl[0];
+        }
         $stream = new Stream($streamUrl);
 
         if (array_key_exists('bargeIn', $data)) {

--- a/test/Voice/NCCO/Action/StreamTest.php
+++ b/test/Voice/NCCO/Action/StreamTest.php
@@ -31,4 +31,20 @@ class StreamTest extends VonageTestCase
             ->setLoop(1)
             ->jsonSerialize());
     }
+
+    public function testFactoryWithArray(): void
+    {
+        $this->assertSame([
+            'action' => 'stream',
+            'streamUrl' => ['https://test.domain/music.mp3']
+        ], Stream::factory(['https://test.domain/music.mp3'], [])->toNCCOArray());
+    }
+
+    public function testFactoryWithString(): void
+    {
+        $this->assertSame([
+            'action' => 'stream',
+            'streamUrl' => ['https://test.domain/music.mp3']
+        ], Stream::factory('https://test.domain/music.mp3', [])->toNCCOArray());
+    }
 }

--- a/test/Voice/NCCO/NCCOTest.php
+++ b/test/Voice/NCCO/NCCOTest.php
@@ -89,4 +89,271 @@ class NCCOTest extends VonageTestCase
         $this->assertCount(7, $json);
         $this->assertEquals($data[0], $json[0]);
     }
+
+    public function testCanCreateFromValidNCCOArray(): void
+    {
+        $data = [
+            [
+                "action" => "talk",
+                "text" => "Thank you for trying Vonage",
+                "bargeIn" => "false",
+                "level" => "0",
+                "loop" => "1",
+                "language" => "en-US",
+                "style" => "0",
+                "premium" => "false",
+            ],
+            [
+                "action" => "record",
+                "format" => "wav",
+                "beepStart" => "true",
+                "endOnSilence" => "4",
+                "endOnKey" => "#",
+                "channels" => "12",
+                "split" => "conversation",
+                "timeOut" => "7200",
+                "eventUrl" => [
+                    "http://domain.test/event",
+                ],
+                "eventMethod" => "POST",
+            ],
+            [
+                "action" => "conversation",
+                "name" => "Sample Conversation",
+                "startOnEnter" => "true",
+                "endOnExit" => "false",
+                "record" => "true",
+                "canSpeak" => [
+                    "49502bca-da71-44bb-b3a6-5077b58c2690",
+                ],
+                "canHear" => [
+                    "798146f0-af79-468a-83a4-b6fcda7cd4e6",
+                ],
+            ],
+            [
+                "action" => "connect",
+                "endpoint" => [
+                    [
+                        "type" => "phone",
+                        "number" => "447700900001",
+                    ],
+                ],
+            ],
+            [
+                "action" => "talk",
+                "text" => "Thank you for trying Vonage",
+                "bargeIn" => "false",
+                "level" => "0",
+                "loop" => "1",
+                "language" => "en-US",
+                "style" => "0",
+                "premium" => "false",
+            ],
+            [
+                "action" => "record",
+                "format" => "wav",
+                "beepStart" => "true",
+                "endOnSilence" => "4",
+                "endOnKey" => "#",
+                "channels" => "12",
+                "split" => "conversation",
+                "timeOut" => "7200",
+                "eventUrl" => [
+                    "http://domain.test/event",
+                ],
+                "eventMethod" => "POST",
+            ],
+            [
+                "action" => "conversation",
+                "name" => "Sample Conversation",
+                "startOnEnter" => "true",
+                "endOnExit" => "false",
+                "record" => "true",
+                "canSpeak" => [
+                    "49502bca-da71-44bb-b3a6-5077b58c2690",
+                ],
+                "canHear" => [
+                    "798146f0-af79-468a-83a4-b6fcda7cd4e6",
+                ],
+            ],
+            [
+                "action" => "connect",
+                "endpoint" => [
+                    [
+                        "type" => "phone",
+                        "number" => "447700900001",
+                    ],
+                ],
+            ],
+            [
+                "action" => "stream",
+                "streamUrl" => [
+                    "http://domain.test/music.mp3",
+                ],
+                "bargeIn" => "true",
+                "level" => "0.1",
+                "loop" => "0",
+            ],
+            [
+                "action" => "input",
+                "dtmf" => [
+                    "maxDigits" => 1,
+                ],
+                "speech" => [
+                    "uuid" => [
+                        "49502bca-da71-44bb-b3a6-5077b58c2690",
+                    ],
+                    "maxDuration" => 30,
+                ],
+            ],
+            [
+                "action" => "notify",
+                "payload" => [
+                    "foo" => "bar",
+                ],
+                "eventUrl" => [
+                    "http://domain.test/event",
+                ],
+                "eventMethod" => "POST",
+            ],
+        ];
+        $ncco = new NCCO();
+        $ncco->fromArray($data);
+        $this->assertEquals(json_encode($data), json_encode($ncco));
+    }
+
+    public function testCanConvertToAndFromArray(): void
+    {
+        $data = [
+            [
+                "action" => "talk",
+                "text" => "Thank you for trying Vonage",
+                "bargeIn" => "false",
+                "level" => "0",
+                "loop" => "1",
+                "language" => "en-US",
+                "style" => "0",
+                "premium" => "false",
+            ],
+            [
+                "action" => "record",
+                "format" => "wav",
+                "beepStart" => "true",
+                "endOnSilence" => "4",
+                "endOnKey" => "#",
+                "channels" => "12",
+                "split" => "conversation",
+                "timeOut" => "7200",
+                "eventUrl" => [
+                    "http://domain.test/event",
+                ],
+                "eventMethod" => "POST",
+            ],
+            [
+                "action" => "conversation",
+                "name" => "Sample Conversation",
+                "startOnEnter" => "true",
+                "endOnExit" => "false",
+                "record" => "true",
+                "canSpeak" => [
+                    "49502bca-da71-44bb-b3a6-5077b58c2690",
+                ],
+                "canHear" => [
+                    "798146f0-af79-468a-83a4-b6fcda7cd4e6",
+                ],
+            ],
+            [
+                "action" => "connect",
+                "endpoint" => [
+                    [
+                        "type" => "phone",
+                        "number" => "447700900001",
+                    ],
+                ],
+            ],
+            [
+                "action" => "talk",
+                "text" => "Thank you for trying Vonage",
+                "bargeIn" => "false",
+                "level" => "0",
+                "loop" => "1",
+                "language" => "en-US",
+                "style" => "0",
+                "premium" => "false",
+            ],
+            [
+                "action" => "record",
+                "format" => "wav",
+                "beepStart" => "true",
+                "endOnSilence" => "4",
+                "endOnKey" => "#",
+                "channels" => "12",
+                "split" => "conversation",
+                "timeOut" => "7200",
+                "eventUrl" => [
+                    "http://domain.test/event",
+                ],
+                "eventMethod" => "POST",
+            ],
+            [
+                "action" => "conversation",
+                "name" => "Sample Conversation",
+                "startOnEnter" => "true",
+                "endOnExit" => "false",
+                "record" => "true",
+                "canSpeak" => [
+                    "49502bca-da71-44bb-b3a6-5077b58c2690",
+                ],
+                "canHear" => [
+                    "798146f0-af79-468a-83a4-b6fcda7cd4e6",
+                ],
+            ],
+            [
+                "action" => "connect",
+                "endpoint" => [
+                    [
+                        "type" => "phone",
+                        "number" => "447700900001",
+                    ],
+                ],
+            ],
+            [
+                "action" => "stream",
+                "streamUrl" => [
+                    "http://domain.test/music.mp3",
+                ],
+                "bargeIn" => "true",
+                "level" => "0.1",
+                "loop" => "0",
+            ],
+            [
+                "action" => "input",
+                "dtmf" => [
+                    "maxDigits" => 1,
+                ],
+                "speech" => [
+                    "uuid" => [
+                        "49502bca-da71-44bb-b3a6-5077b58c2690",
+                    ],
+                    "maxDuration" => 30,
+                ],
+            ],
+            [
+                "action" => "notify",
+                "payload" => [
+                    "foo" => "bar",
+                ],
+                "eventUrl" => [
+                    "http://domain.test/event",
+                ],
+                "eventMethod" => "POST",
+            ],
+        ];
+        $ncco1 = new NCCO();
+        $ncco2 = new NCCO();
+        $ncco1->fromArray($data);
+        $ncco2->fromArray($ncco1->toArray());
+        $this->assertEquals($ncco1->toArray(), $ncco2->toArray());
+        $this->assertEquals(json_encode($data), json_encode($ncco2));
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added array type to factory method of `Vonage\Voice\NCCO\Action\Stream`
- Added `is_object` check for `dtmf` and `speech` parameters in factory method of `Vonage\Voice\NCCO\Action\Input` 
- Added `is_array` check for `eventUrl` in factory methods of `Vonage\Voice\NCCO\Action\Notify` and `Vonage\Voice\NCCO\Action\Record`
- Added casting to integer for `channels` and `timeOut` parameters in factory method of `Vonage\Voice\NCCO\Action\Record`

## Motivation and Context
- Fixes issue #494 
- Previously, trying to create NCCO object from a valid NCCO array would incorrectly fail in certain cases.

## How Has This Been Tested?
Added the following tests
1. `VonageTest\Voice\NCCO\Action\StreamTest::testFactoryWithArray` 
    Tests if `Stream::factory` can be passed an array with a stream url
  
2. `VonageTest\Voice\NCCO\Action\StreamTest::testFactoryWithString` 
    Tests if `Stream::factory` can be passed a string as a stream url (current behaviour)
  
3. `VonageTest\Voice\NCCO\NCCOTest::testCanCreateFromValidNCCOArray` 
    Tests if `NCCO::fromArray` can be passed a valid NCCO array

4. `VonageTest\Voice\NCCO\NCCOTest::testCanConvertToAndFromArray` 
    Tests if `NCCO` class can convert to an NCCO array and then from that array

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
