### PR TITLE
correct the nullcheck on whatsapp context.

### DIFF
--- a/src/Messages/Channel/WhatsApp/WhatsAppText.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppText.php
@@ -28,10 +28,7 @@ class WhatsAppText extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['text'] = $this->getText();
-
-        if (property_exists($this, 'context') && !is_null($this->context)) {
-            $returnArray['context'] = $this->context;
-        }
+        $returnArray['context'] = $this->context ?? null;
 
         return $returnArray;
     }

--- a/src/Messages/Channel/WhatsApp/WhatsAppText.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppText.php
@@ -29,7 +29,7 @@ class WhatsAppText extends BaseMessage
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['text'] = $this->getText();
 
-        if (!is_null($this->context)) {
+        if (property_exists($this, 'context') && !is_null($this->context)) {
             $returnArray['context'] = $this->context;
         }
 

--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -318,6 +318,30 @@ class ClientTest extends VonageTestCase
         $this->assertArrayHasKey('message_uuid', $result);
     }
 
+    public function testCanSendWhatsAppTextWithoutContext(): void
+    {
+        $payload = [
+            'to' => '447700900000',
+            'from' => '16105551212',
+            'text' => 'This is a WhatsApp text'
+        ];
+
+        $message = new WhatsAppText($payload['to'], $payload['from'], $payload['text']);
+
+        $this->vonageClient->send(Argument::that(function (Request $request) use ($payload) {
+            $this->assertRequestJsonBodyContains('to', $payload['to'], $request);
+            $this->assertRequestJsonBodyContains('from', $payload['from'], $request);
+            $this->assertRequestJsonBodyContains('text', $payload['text'], $request);
+            $this->assertRequestJsonBodyContains('channel', 'whatsapp', $request);
+            $this->assertRequestJsonBodyContains('message_type', 'text', $request);
+            $this->assertEquals('POST', $request->getMethod());
+
+            return true;
+        }))->willReturn($this->getResponse('sms-success', 202));
+        $result = $this->messageClient->send($message);
+        $this->assertIsArray($result);
+    }
+
     public function testCanSendWhatsAppImage(): void
     {
         $imageUrl = 'https://picsum.photos/200/300';


### PR DESCRIPTION
The toArray function on a WhatsAppText object implements the ContextTrait incorrectly.

## Description
When rendering the text, it is possible that context has not been set as it is an optional object. This PR fixes that by checking with property_exists

## Motivation and Context
Reported by custom attempting to use the Messages API

## How Has This Been Tested?
Test has been added

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
