### PR TITLE
Add nullsafe checks for API response

### DIFF
--- a/src/Messages/ExceptionErrorHandler.php
+++ b/src/Messages/ExceptionErrorHandler.php
@@ -40,6 +40,12 @@ class ExceptionErrorHandler
             throw new ClientException\Server($responseBody['title'] . ': ' . $responseBody['detail']);
         }
 
-        throw new ClientException\Request($responseBody['title'] . ': ' . $responseBody['detail']);
+        $message = $responseBody['title'] ?? '';
+
+        if (isset($responseBody['detail'])) {
+            $message .= ': ' . $responseBody['detail'];
+        }
+
+        throw new ClientException\Request($message);
     }
 }


### PR DESCRIPTION
Small bug patch for when the 'detail' field is not present in a Messages API Error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
