### PR TITLE
Feature/typehint hardening

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: "#^Method Vonage\\\\Client\\:\\:setLogger\\(\\) should return Vonage\\\\Logger\\\\LoggerAwareInterface but return statement is missing\\.$#"
-			count: 1
-			path: src/Client.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Client/Callback/Callback.php

--- a/src/Account/Balance.php
+++ b/src/Account/Balance.php
@@ -9,23 +9,20 @@ use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 class Balance implements
     ArrayHydrateInterface
 {
-    /**
-     * @var array
-     */
     protected array $data;
 
-    public function __construct($balance, $autoReload)
+    public function __construct(float $balance, bool $autoReload)
     {
         $this->data['balance'] = $balance;
         $this->data['auto_reload'] = $autoReload;
     }
 
-    public function getBalance()
+    public function getBalance(): float
     {
         return $this->data['balance'];
     }
 
-    public function getAutoReload()
+    public function getAutoReload(): bool
     {
         return $this->data['auto_reload'];
     }

--- a/src/Account/Client.php
+++ b/src/Account/Client.php
@@ -34,7 +34,7 @@ class Client implements APIClient
      *
      * @return array<PrefixPrice>
      */
-    public function getPrefixPricing($prefix): array
+    public function getPrefixPricing(string $prefix): array
     {
         $api = $this->getAPIResource();
         $api->setBaseUri('/account/get-prefix-pricing/outbound');
@@ -138,7 +138,7 @@ class Client implements APIClient
      * @throws ClientExceptionInterface
      * @throws ClientException\Exception
      */
-    public function topUp($trx): void
+    public function topUp(string $trx): void
     {
         $api = $this->getAPIResource();
         $api->setBaseUri('/account/top-up');

--- a/src/Account/ClientFactory.php
+++ b/src/Account/ClientFactory.php
@@ -7,6 +7,7 @@ namespace Vonage\Account;
 use Psr\Container\ContainerInterface;
 use Vonage\Client\APIResource;
 use Vonage\Client\Credentials\Handler\BasicQueryHandler;
+
 class ClientFactory
 {
     public function __invoke(ContainerInterface $container): Client

--- a/src/Account/Config.php
+++ b/src/Account/Config.php
@@ -14,19 +14,14 @@ class Config implements
     /**
      * @var array<string, mixed>
      */
-    protected $data = [];
+    protected array $data = [];
 
-    /**
-     * @param string|int|null $max_outbound_request
-     * @param string|int|null $max_inbound_request
-     * @param string|int|null $max_calls_per_second
-     */
     public function __construct(
         ?string $sms_callback_url = null,
         ?string $dr_callback_url = null,
-        $max_outbound_request = null,
-        $max_inbound_request = null,
-        $max_calls_per_second = null
+        int|string $max_outbound_request = null,
+        int|string $max_inbound_request = null,
+        int|string $max_calls_per_second = null
     ) {
         if (!is_null($sms_callback_url)) {
             $this->data['sms_callback_url'] = $sms_callback_url;
@@ -59,26 +54,17 @@ class Config implements
         return $this->data['dr_callback_url'];
     }
 
-    /**
-     * @return string|int|null
-     */
-    public function getMaxOutboundRequest()
+    public function getMaxOutboundRequest(): int|string|null
     {
         return $this->data['max_outbound_request'];
     }
 
-    /**
-     * @return string|int|null
-     */
-    public function getMaxInboundRequest()
+    public function getMaxInboundRequest(): int|string|null
     {
         return $this->data['max_inbound_request'];
     }
 
-    /**
-     * @return string|int|null
-     */
-    public function getMaxCallsPerSecond()
+    public function getMaxCallsPerSecond(): int|string|null
     {
         return $this->data['max_calls_per_second'];
     }

--- a/src/Account/Network.php
+++ b/src/Account/Network.php
@@ -22,16 +22,9 @@ class Network implements
     use NoRequestResponseTrait;
     use JsonResponseTrait;
 
-    /**
-     * @var array
-     */
     protected array $data = [];
 
-    /**
-     * @param string|int $networkCode
-     * @param string|int $networkName
-     */
-    public function __construct($networkCode, $networkName)
+    public function __construct(int|string $networkCode, int|string $networkName)
     {
         $this->data['network_code'] = (string)$networkCode;
         $this->data['network_name'] = (string)$networkName;
@@ -47,12 +40,12 @@ class Network implements
         return $this->data['network_name'];
     }
 
-    public function getOutboundSmsPrice()
+    public function getOutboundSmsPrice(): mixed
     {
         return $this->data['sms_price'] ?? $this->data['price'];
     }
 
-    public function getOutboundVoicePrice()
+    public function getOutboundVoicePrice(): mixed
     {
         return $this->data['voice_price'] ?? $this->data['price'];
     }

--- a/src/Account/PrefixPrice.php
+++ b/src/Account/PrefixPrice.php
@@ -8,11 +8,8 @@ use Vonage\Client\Exception\Exception as ClientException;
 
 class PrefixPrice extends Price
 {
-    protected $priceMethod = 'getPrefixPrice';
+    protected string $priceMethod = 'getPrefixPrice';
 
-    /**
-     * @throws ClientException
-     */
     public function getCurrency(): ?string
     {
         throw new ClientException('Currency is unavailable from this endpoint');

--- a/src/Account/Price.php
+++ b/src/Account/Price.php
@@ -23,12 +23,9 @@ abstract class Price implements
     use NoRequestResponseTrait;
     use JsonResponseTrait;
 
-    /**
-     * @var array<string, mixed>
-     */
-    protected $data = [];
+    protected array $data = [];
 
-    public function getCountryCode()
+    public function getCountryCode(): mixed
     {
         return $this->data['country_code'];
     }
@@ -43,12 +40,12 @@ abstract class Price implements
         return $this->data['country_name'];
     }
 
-    public function getDialingPrefix()
+    public function getDialingPrefix(): mixed
     {
         return $this->data['dialing_prefix'];
     }
 
-    public function getDefaultPrice()
+    public function getDefaultPrice(): mixed
     {
         if (isset($this->data['default_price'])) {
             return $this->data['default_price'];
@@ -68,7 +65,7 @@ abstract class Price implements
         return $this->data['currency'];
     }
 
-    public function getNetworks()
+    public function getNetworks(): mixed
     {
         return $this->data['networks'];
     }

--- a/src/Account/SmsPrice.php
+++ b/src/Account/SmsPrice.php
@@ -3,10 +3,8 @@
 declare(strict_types=1);
 
 namespace Vonage\Account;
+
 class SmsPrice extends Price
 {
-    /**
-     * @var string
-     */
-    protected $priceMethod = 'getOutboundSmsPrice';
+    protected string $priceMethod = 'getOutboundSmsPrice';
 }

--- a/src/Account/VoicePrice.php
+++ b/src/Account/VoicePrice.php
@@ -3,10 +3,8 @@
 declare(strict_types=1);
 
 namespace Vonage\Account;
+
 class VoicePrice extends Price
 {
-    /**
-     * @var string
-     */
-    protected $priceMethod = 'getOutboundVoicePrice';
+    protected string $priceMethod = 'getOutboundVoicePrice';
 }

--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -22,32 +22,17 @@ class Application implements EntityInterface, JsonSerializable, ArrayHydrateInte
     use Psr7Trait;
     use JsonResponseTrait;
 
-    /**
-     * @var VoiceConfig
-     */
-    protected $voiceConfig;
+    protected VoiceConfig $voiceConfig;
 
-    /**
-     * @var MessagesConfig
-     */
-    protected $messagesConfig;
+    protected MessagesConfig $messagesConfig;
 
-    /**
-     * @var RtcConfig
-     */
-    protected $rtcConfig;
+    protected RtcConfig $rtcConfig;
 
-    /**
-     * @var VbcConfig
-     */
-    protected $vbcConfig;
+    protected VbcConfig $vbcConfig;
 
-    protected $name;
+    protected ?string $name = null;
 
-    /**
-     * @var array
-     */
-    protected $keys = [];
+    protected array $keys = [];
 
     public function __construct(protected ?string $id = null)
     {

--- a/src/Application/MessagesConfig.php
+++ b/src/Application/MessagesConfig.php
@@ -11,10 +11,7 @@ class MessagesConfig
     public const INBOUND = 'inbound_url';
     public const STATUS = 'status_url';
 
-    /**
-     * @var array
-     */
-    protected $webhooks = [];
+    protected array $webhooks = [];
 
     public function setWebhook($type, $url, $method = null): self
     {

--- a/src/Application/RtcConfig.php
+++ b/src/Application/RtcConfig.php
@@ -10,10 +10,7 @@ class RtcConfig
 {
     public const EVENT = 'event_url';
 
-    /**
-     * @var array
-     */
-    protected $webhooks = [];
+    protected array $webhooks = [];
 
     public function setWebhook($type, $url, $method = null): self
     {

--- a/src/Application/VbcConfig.php
+++ b/src/Application/VbcConfig.php
@@ -6,10 +6,7 @@ namespace Vonage\Application;
 
 class VbcConfig
 {
-    /**
-     * @var bool
-     */
-    protected $enabled = false;
+    protected bool $enabled = false;
 
     public function enable(): void
     {

--- a/src/Application/VoiceConfig.php
+++ b/src/Application/VoiceConfig.php
@@ -23,10 +23,7 @@ class VoiceConfig
         'apac-australia'
     ];
 
-    /**
-     * @var array
-     */
-    protected $webhooks = [];
+    protected array $webhooks = [];
 
     public function setWebhook($type, $url, $method = null): self
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -102,49 +102,24 @@ class Client implements LoggerAwareInterface
     public const BASE_API = 'https://api.nexmo.com';
     public const BASE_REST = 'https://rest.nexmo.com';
 
-    /**
-     * API Credentials
-     *
-     * @var CredentialsInterface
-     */
-    protected $credentials;
+    protected CredentialsInterface $credentials;
 
-    /**
-     * Http Client
-     *
-     * @var HttpClient
-     */
-    protected $client;
+    protected ClientInterface $client;
 
-    /**
-     * @var bool
-     */
-    protected $debug = false;
+    protected mixed $debug = false;
 
-    /**
-     * @var ContainerInterface
-     */
-    protected $factory;
+    protected ContainerInterface $factory;
 
     /**
      * @var LoggerInterface
      */
     protected $logger;
 
-    /**
-     * @var array
-     */
-    protected $options = ['show_deprecations' => false, 'debug' => false];
+    protected array $options = ['show_deprecations' => false, 'debug' => false];
 
-    /**
-     * @string
-     */
-    public $apiUrl;
+    public string $apiUrl;
 
-    /**
-     * @string
-     */
-    public $restUrl;
+    public string $restUrl;
 
     /**
      * Create a new API client using the provided credentials.

--- a/src/Client/Callback/Callback.php
+++ b/src/Client/Callback/Callback.php
@@ -19,15 +19,9 @@ class Callback implements CallbackInterface
     public const ENV_POST = 'post';
     public const ENV_GET = 'get';
 
-    /**
-     * @var array
-     */
-    protected $expected = [];
+    protected array $expected = [];
 
-    /**
-     * @var array
-     */
-    protected $data;
+    protected array $data;
 
     public function __construct(array $data)
     {
@@ -46,10 +40,7 @@ class Callback implements CallbackInterface
         return $this->data;
     }
 
-    /**
-     * @return Callback|callable
-     */
-    public static function fromEnv(string $source = self::ENV_ALL)
+    public static function fromEnv(string $source = self::ENV_ALL): callable|Callback
     {
         $data = match (strtolower($source)) {
             'post' => $_POST,

--- a/src/Client/Credentials/AbstractCredentials.php
+++ b/src/Client/Credentials/AbstractCredentials.php
@@ -6,9 +6,6 @@ namespace Vonage\Client\Credentials;
 
 abstract class AbstractCredentials implements CredentialsInterface
 {
-    /**
-     * @var array
-     */
     protected array $credentials = [];
 
     /**

--- a/src/Client/Credentials/Basic.php
+++ b/src/Client/Credentials/Basic.php
@@ -7,17 +7,11 @@ namespace Vonage\Client\Credentials;
 /**
  * Class Basic
  * Read-only container for api key and secret.
- *
- * @property string api_key
- * @property string api_secret
  */
 class Basic extends AbstractCredentials
 {
     /**
      * Create a credential set with an API key and secret.
-     *
-     * @param $key
-     * @param $secret
      */
     public function __construct($key, $secret)
     {

--- a/src/Client/Credentials/Handler/BasicHandler.php
+++ b/src/Client/Credentials/Handler/BasicHandler.php
@@ -15,8 +15,6 @@ class BasicHandler extends AbstractHandler
         $c = $credentials->asArray();
         $cx = base64_encode($c['api_key'] . ':' . $c['api_secret']);
 
-        $request = $request->withHeader('Authorization', 'Basic ' . $cx);
-
-        return $request;
+        return $request->withHeader('Authorization', 'Basic ' . $cx);
     }
 }

--- a/src/Client/Credentials/Keypair.php
+++ b/src/Client/Credentials/Keypair.php
@@ -11,9 +11,6 @@ use Lcobucci\JWT\Token;
 use Vonage\Application\Application;
 use Vonage\JWT\TokenGenerator;
 
-/**
- * @property mixed application
- */
 class Keypair extends AbstractCredentials
 {
     public function __construct(protected string $key, protected ?string $application = null)
@@ -21,10 +18,6 @@ class Keypair extends AbstractCredentials
         $this->credentials['key'] = $key;
 
         if ($application) {
-            if ($application instanceof Application) {
-                $application = $application->getId();
-            }
-
             $this->credentials['application'] = $application;
         }
     }

--- a/src/Conversation/ClientFactory.php
+++ b/src/Conversation/ClientFactory.php
@@ -5,7 +5,6 @@ namespace Vonage\Conversation;
 use Psr\Container\ContainerInterface;
 use Vonage\Client\APIResource;
 use Vonage\Client\Credentials\Handler\KeypairHandler;
-use Vonage\Conversation\Client;
 
 class ClientFactory
 {

--- a/src/Conversation/ConversationObjects/Channel.php
+++ b/src/Conversation/ConversationObjects/Channel.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Vonage\Conversation\ConversationObjects;
 
-use phpDocumentor\Reflection\Types\This;
 use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 
 class Channel implements ArrayHydrateInterface

--- a/src/Conversation/ConversationObjects/CreateConversationRequest.php
+++ b/src/Conversation/ConversationObjects/CreateConversationRequest.php
@@ -105,7 +105,7 @@ class CreateConversationRequest implements ArrayHydrateInterface
         return $this;
     }
 
-    public function fromArray(array $data)
+    public function fromArray(array $data): void
     {
         if (isset($data['name'])) {
             $this->setName($data['name']);

--- a/src/Conversion/Client.php
+++ b/src/Conversion/Client.php
@@ -13,7 +13,6 @@ use Vonage\Client\ClientAwareTrait;
 use Vonage\Client\Exception as ClientException;
 
 use function http_build_query;
-use function is_null;
 use function json_decode;
 
 class Client implements ClientAwareInterface, APIClient
@@ -91,13 +90,10 @@ class Client implements ClientAwareInterface, APIClient
         }
     }
 
-    /**
-     * @return ClientException\Exception|ClientException\Request|ClientException\Server
-     */
-    protected function getException(ResponseInterface $response)
+    protected function getException(ResponseInterface $response): ClientException\Exception|ClientException\Request|ClientException\Server
     {
         $body = json_decode($response->getBody()->getContents(), true);
-        $status = (int)$response->getStatusCode();
+        $status = $response->getStatusCode();
 
         if ($status === 402) {
             $e = new ClientException\Request('This endpoint may need activating on your account. ' .

--- a/src/Conversion/ClientFactory.php
+++ b/src/Conversion/ClientFactory.php
@@ -9,11 +9,10 @@ use Vonage\Client\APIResource;
 use Vonage\Client\Credentials\Handler\BasicHandler;
 
 /**
- * @todo Finish this Namespace
+ * @TODO Finish this Namespace
  */
 class ClientFactory
 {
-
     public function __invoke(ContainerInterface $container): Client
     {
         /** @var APIResource $api */

--- a/src/Entity/Filter/DateFilter.php
+++ b/src/Entity/Filter/DateFilter.php
@@ -13,8 +13,8 @@ class DateFilter implements FilterInterface
 {
     public const FORMAT = 'Y:m:d:H:i:s';
 
-    protected $start;
-    protected $end;
+    protected DateTime $start;
+    protected DateTime $end;
 
     public function __construct(DateTime $start, DateTime $end)
     {
@@ -27,9 +27,6 @@ class DateFilter implements FilterInterface
         }
     }
 
-    /**
-     * @return string[]
-     */
     public function getQuery(): array
     {
         return [

--- a/src/Entity/HasEntityTrait.php
+++ b/src/Entity/HasEntityTrait.php
@@ -8,9 +8,6 @@ trait HasEntityTrait
 {
     protected $entity;
 
-    /**
-     * @param $entity
-     */
     public function setEntity($entity): void
     {
         $this->entity = $entity;

--- a/src/Entity/Hydrator/ArrayHydrator.php
+++ b/src/Entity/Hydrator/ArrayHydrator.php
@@ -6,10 +6,7 @@ namespace Vonage\Entity\Hydrator;
 
 class ArrayHydrator implements HydratorInterface
 {
-    /**
-     * @var ArrayHydrateInterface
-     */
-    protected $prototype;
+    protected ArrayHydrateInterface $prototype;
 
     public function hydrate(array $data): ArrayHydrateInterface
     {
@@ -19,9 +16,6 @@ class ArrayHydrator implements HydratorInterface
         return $object;
     }
 
-    /**
-     * @param $object
-     */
     public function hydrateObject(array $data, $object)
     {
         $object->fromArray($data);

--- a/src/Entity/Hydrator/ConstructorHydrator.php
+++ b/src/Entity/Hydrator/ConstructorHydrator.php
@@ -6,21 +6,14 @@ namespace Vonage\Entity\Hydrator;
 
 class ConstructorHydrator implements HydratorInterface
 {
-    /**
-     * Class to create
-     * @var string
-     */
-    protected $prototype;
+    protected string $prototype;
 
-    public function hydrate(array $data)
+    public function hydrate(array $data): mixed
     {
         $className = $this->prototype;
         return new $className($data);
     }
 
-    /**
-     * @param $object
-     */
     public function hydrateObject(array $data, $object): never
     {
         throw new \RuntimeException('Constructor Hydration can not happen on an existing object');

--- a/src/Entity/Hydrator/HydratorInterface.php
+++ b/src/Entity/Hydrator/HydratorInterface.php
@@ -13,8 +13,6 @@ interface HydratorInterface
 
     /**
      * Hydrate an existing object created outside of the hydrator
-     *
-     * @param $object
      */
     public function hydrateObject(array $data, $object);
 }

--- a/src/Entity/IterableAPICollection.php
+++ b/src/Entity/IterableAPICollection.php
@@ -15,6 +15,8 @@ use Vonage\Client\APIResource;
 use Vonage\Client\ClientAwareInterface;
 use Vonage\Client\ClientAwareTrait;
 use Vonage\Client\Exception as ClientException;
+use Vonage\Client\Exception\Exception;
+use Vonage\Client\Exception\Server;
 use Vonage\Entity\Filter\EmptyFilter;
 use Vonage\Entity\Filter\FilterInterface;
 
@@ -26,7 +28,6 @@ use function http_build_query;
 use function is_null;
 use function json_decode;
 use function md5;
-use function strpos;
 
 /**
  * Common code for iterating over a collection, and using the collection class to discover the API path.
@@ -402,7 +403,7 @@ class IterableAPICollection implements ClientAwareInterface, Iterator, Countable
     /**
      * @return int|mixed
      */
-    public function getPage()
+    public function getPage(): mixed
     {
         if (isset($this->pageData)) {
             if (array_key_exists('page', $this->pageData)) {
@@ -459,11 +460,6 @@ class IterableAPICollection implements ClientAwareInterface, Iterator, Countable
         throw new RuntimeException('size not set');
     }
 
-    /**
-     * @param $size
-     *
-     * @return $this
-     */
     public function setSize($size): self
     {
         $this->size = (int)$size;
@@ -473,8 +469,6 @@ class IterableAPICollection implements ClientAwareInterface, Iterator, Countable
 
     /**
      * Filters reduce to query params and include paging settings.
-     *
-     * @return $this
      */
     public function setFilter(FilterInterface $filter): self
     {
@@ -493,8 +487,6 @@ class IterableAPICollection implements ClientAwareInterface, Iterator, Countable
 
     /**
      * Fetch a page using the current filter if no query is provided.
-     *
-     * @param $absoluteUri
      *
      * @throws ClientException\Exception
      * @throws ClientException\Request
@@ -564,12 +556,7 @@ class IterableAPICollection implements ClientAwareInterface, Iterator, Countable
         }
     }
 
-    /**
-     * @throws ClientException\Exception
-     *
-     * @return ClientException\Request|ClientException\Server
-     */
-    protected function getException(ResponseInterface $response)
+    protected function getException(ResponseInterface $response): ClientException\Request|ClientException\Server
     {
         $response->getBody()->rewind();
         $body = json_decode($response->getBody()->getContents(), true);
@@ -599,9 +586,6 @@ class IterableAPICollection implements ClientAwareInterface, Iterator, Countable
         return $this->autoAdvance;
     }
 
-    /**
-     * @return $this
-     */
     public function setAutoAdvance(bool $autoAdvance): self
     {
         $this->autoAdvance = $autoAdvance;
@@ -614,9 +598,6 @@ class IterableAPICollection implements ClientAwareInterface, Iterator, Countable
         return $this->naiveCount;
     }
 
-    /**
-     * @return $this
-     */
     public function setNaiveCount(bool $naiveCount): self
     {
         $this->naiveCount = $naiveCount;
@@ -643,9 +624,6 @@ class IterableAPICollection implements ClientAwareInterface, Iterator, Countable
         return $this;
     }
 
-    /**
-     * @return bool
-     */
     public function hasPagination(): bool
     {
         return $this->hasPagination;

--- a/src/Entity/Psr7Trait.php
+++ b/src/Entity/Psr7Trait.php
@@ -22,8 +22,8 @@ use function trigger_error;
  */
 trait Psr7Trait
 {
-    protected RequestInterface $request;
-    protected ResponseInterface $response;
+    protected ?RequestInterface $request = null;
+    protected ?ResponseInterface $response = null;
 
     /**
      * @deprecated See error

--- a/src/Entity/Psr7Trait.php
+++ b/src/Entity/Psr7Trait.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 
 use function array_merge;
-use function get_class;
 use function is_array;
 use function json_decode;
 use function method_exists;
@@ -23,15 +22,8 @@ use function trigger_error;
  */
 trait Psr7Trait
 {
-    /**
-     * @var RequestInterface
-     */
-    protected $request;
-
-    /**
-     * @var ResponseInterface
-     */
-    protected $response;
+    protected RequestInterface $request;
+    protected ResponseInterface $response;
 
     /**
      * @deprecated See error

--- a/src/Insights/Advanced.php
+++ b/src/Insights/Advanced.php
@@ -6,13 +6,12 @@ namespace Vonage\Insights;
 
 class Advanced extends Standard
 {
-
-    public function getValidNumber()
+    public function getValidNumber(): mixed
     {
         return $this->data['valid_number'];
     }
 
-    public function getReachable()
+    public function getReachable(): mixed
     {
         return $this->data['reachable'];
     }

--- a/src/Insights/Basic.php
+++ b/src/Insights/Basic.php
@@ -5,15 +5,11 @@ declare(strict_types=1);
 namespace Vonage\Insights;
 
 use Vonage\Entity\Hydrator\ArrayHydrateInterface;
-
 class Basic implements ArrayHydrateInterface
 {
     protected array $data = [];
 
-    /**
-     * @param $number
-     */
-    public function __construct($number)
+    public function __construct(string $number)
     {
         $this->data['national_format_number'] = $number;
     }

--- a/src/Insights/Client.php
+++ b/src/Insights/Client.php
@@ -32,98 +32,88 @@ class Client implements APIClient
     }
 
     /**
-     * @param $number
-     *
-     * @return Basic
      * @throws ClientExceptionInterface
      * @throws Exception
      * @throws Request
      * @throws Server
      */
-    public function basic($number): Basic
+    public function basic(string $number): Basic
     {
         $insightsResults = $this->makeRequest('/ni/basic/json', $number);
 
         $basic = new Basic($insightsResults['national_format_number']);
         $basic->fromArray($insightsResults);
+
         return $basic;
     }
 
     /**
-     * @param $number
-     *
-     * @return StandardCnam
      * @throws ClientExceptionInterface
      * @throws Exception
      * @throws Request
      * @throws Server
      */
-    public function standardCNam($number): StandardCnam
+    public function standardCNam(string $number): StandardCnam
     {
         $insightsResults = $this->makeRequest('/ni/standard/json', $number, ['cnam' => 'true']);
         $standard = new StandardCnam($insightsResults['national_format_number']);
         $standard->fromArray($insightsResults);
+
         return $standard;
     }
 
     /**
-     * @param $number
-     *
-     * @return AdvancedCnam
      * @throws ClientExceptionInterface
      * @throws Exception
      * @throws Request
      * @throws Server
      */
-    public function advancedCnam($number): AdvancedCnam
+    public function advancedCnam(string $number): AdvancedCnam
     {
         $insightsResults = $this->makeRequest('/ni/advanced/json', $number, ['cnam' => 'true']);
         $standard = new AdvancedCnam($insightsResults['national_format_number']);
         $standard->fromArray($insightsResults);
+
         return $standard;
     }
 
     /**
-     * @param $number
-     *
      * @throws ClientExceptionInterface
      * @throws ClientException\Exception
      * @throws ClientException\Request
      * @throws ClientException\Server
      */
-    public function standard($number): Standard
+    public function standard(string $number): Standard
     {
         $insightsResults = $this->makeRequest('/ni/standard/json', $number);
         $standard = new Standard($insightsResults['national_format_number']);
         $standard->fromArray($insightsResults);
+
         return $standard;
     }
 
     /**
-     * @param $number
-     *
      * @throws ClientExceptionInterface
      * @throws ClientException\Exception
      * @throws ClientException\Request
      * @throws ClientException\Server
      */
-    public function advanced($number): Advanced
+    public function advanced(string $number): Advanced
     {
         $insightsResults = $this->makeRequest('/ni/advanced/json', $number);
         $advanced = new Advanced($insightsResults['national_format_number']);
         $advanced->fromArray($insightsResults);
+
         return $advanced;
     }
 
     /**
-     * @param $number
-     *
      * @throws ClientExceptionInterface
      * @throws ClientException\Exception
      * @throws ClientException\Request
      * @throws ClientException\Server
      */
-    public function advancedAsync($number, string $webhook): void
+    public function advancedAsync(string $number, string $webhook): void
     {
         // This method does not have a return value as it's async. If there is no exception thrown
         // We can assume that everything is fine
@@ -132,8 +122,6 @@ class Client implements APIClient
 
     /**
      * Common code for generating a request
-     *
-     * @param $number
      *
      * @throws ClientException\Exception
      * @throws ClientException\Request

--- a/src/Insights/CnamTrait.php
+++ b/src/Insights/CnamTrait.php
@@ -6,7 +6,6 @@ namespace Vonage\Insights;
 
 trait CnamTrait
 {
-
     public function getCallerName(): ?string
     {
         return $this->data['caller_name'] ?? null;

--- a/src/Insights/Standard.php
+++ b/src/Insights/Standard.php
@@ -6,38 +6,37 @@ namespace Vonage\Insights;
 
 class Standard extends Basic
 {
-
-    public function getCurrentCarrier()
+    public function getCurrentCarrier(): mixed
     {
         return $this->data['current_carrier'];
     }
 
-    public function getOriginalCarrier()
+    public function getOriginalCarrier(): mixed
     {
         return $this->data['original_carrier'];
     }
 
-    public function getPorted()
+    public function getPorted(): mixed
     {
         return $this->data['ported'];
     }
 
-    public function getRefundPrice()
+    public function getRefundPrice(): mixed
     {
         return $this->data['refund_price'];
     }
 
-    public function getRequestPrice()
+    public function getRequestPrice(): mixed
     {
         return $this->data['request_price'];
     }
 
-    public function getRemainingBalance()
+    public function getRemainingBalance(): mixed
     {
         return $this->data['remaining_balance'];
     }
 
-    public function getRoaming()
+    public function getRoaming(): mixed
     {
         return $this->data['roaming'];
     }

--- a/src/Logger/LoggerAwareInterface.php
+++ b/src/Logger/LoggerAwareInterface.php
@@ -9,13 +9,10 @@ interface LoggerAwareInterface
     public function getLogger(): ?LoggerInterface;
 
     /**
-     * @param string|int $level Level of message that we are logging
+     * @param int|string $level Level of message that we are logging
      * @param array<mixed> $context Additional information for context
      */
-    public function log($level, string $message, array $context = []): void;
+    public function log(int|string $level, string $message, array $context = []): void;
 
-    /**
-     * @return self
-     */
     public function setLogger(LoggerInterface $logger);
 }

--- a/src/Logger/LoggerAwareInterface.php
+++ b/src/Logger/LoggerAwareInterface.php
@@ -14,5 +14,5 @@ interface LoggerAwareInterface
      */
     public function log(int|string $level, string $message, array $context = []): void;
 
-    public function setLogger(LoggerInterface $logger);
+    public function setLogger(LoggerInterface $logger): void;
 }

--- a/src/Logger/LoggerTrait.php
+++ b/src/Logger/LoggerTrait.php
@@ -28,7 +28,7 @@ trait LoggerTrait
         }
     }
 
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/src/Logger/LoggerTrait.php
+++ b/src/Logger/LoggerTrait.php
@@ -17,10 +17,10 @@ trait LoggerTrait
     }
 
     /**
-     * @param string|int $level Level of message that we are logging
+     * @param int|string $level Level of message that we are logging
      * @param array<mixed> $context Additional information for context
      */
-    public function log($level, string $message, array $context = []): void
+    public function log(int|string $level, string $message, array $context = []): void
     {
         $logger = $this->getLogger();
         if ($logger) {

--- a/src/Network/Number/Callback.php
+++ b/src/Network/Number/Callback.php
@@ -32,7 +32,7 @@ use function substr;
 class Callback extends BaseCallback
 {
     protected array $expected = ['request_id', 'callback_part', 'callback_total_parts', 'number', 'status'];
-    protected $optional = [
+    protected array $optional = [
         'Type' => 'number_type',
         'Network' => 'carrier_network_code',
         'NetworkName' => 'carrier_network_name',
@@ -64,10 +64,6 @@ class Callback extends BaseCallback
         return $this->data['number'];
     }
 
-    /**
-     * @param $name
-     * @param $args
-     */
     public function __call($name, $args)
     {
         $type = substr((string) $name, 0, 3);

--- a/src/Network/Number/Callback.php
+++ b/src/Network/Number/Callback.php
@@ -31,7 +31,7 @@ use function substr;
  */
 class Callback extends BaseCallback
 {
-    protected $expected = ['request_id', 'callback_part', 'callback_total_parts', 'number', 'status'];
+    protected array $expected = ['request_id', 'callback_part', 'callback_total_parts', 'number', 'status'];
     protected $optional = [
         'Type' => 'number_type',
         'Network' => 'carrier_network_code',

--- a/src/Network/Number/Request.php
+++ b/src/Network/Number/Request.php
@@ -26,10 +26,6 @@ class Request extends AbstractRequest implements WrapResponseInterface
      */
     protected $params;
 
-    /**
-     * @param $number
-     * @param $callback
-     */
     public function __construct($number, $callback, array $features = [], $timeout = null, $method = null, $ref = null)
     {
         $this->params['number'] = $number;

--- a/src/Network/Number/Response.php
+++ b/src/Network/Number/Response.php
@@ -13,7 +13,7 @@ use function count;
 
 class Response extends BaseResponse
 {
-    protected $callbacks = [];
+    protected array $callbacks = [];
 
     public function __construct(array $data, array $callbacks = [])
     {
@@ -77,10 +77,7 @@ class Response extends BaseResponse
     }
 
     /**
-     * @param $name
-     * @param $args
-     *
-     * @todo This looks somewhat illogical
+     * @TODO This looks somewhat illogical
      */
     public function __call($name, $args)
     {

--- a/src/Numbers/Filter/AvailableNumbers.php
+++ b/src/Numbers/Filter/AvailableNumbers.php
@@ -32,40 +32,19 @@ class AvailableNumbers implements FilterInterface
         'type' => 'string',
     ];
 
-    /**
-     * @var string
-     */
-    protected $country;
+    protected ?string $country = null;
 
-    /**
-     * @var string
-     */
-    protected $features;
+    protected ?string $features = null;
 
-    /**
-     * @var int
-     */
-    protected $pageIndex = 1;
+    protected int $pageIndex = 1;
 
-    /**
-     * @var int
-     */
-    protected $pageSize = 10;
+    protected int $pageSize = 10;
 
-    /**
-     * @var string
-     */
-    protected $pattern;
+    protected ?string $pattern = null;
 
-    /**
-     * @var int
-     */
-    protected $searchPattern = 0;
+    protected int $searchPattern = 0;
 
-    /**
-     * @var string
-     */
-    protected $type;
+    protected ?string $type = null;
 
     protected ?bool $hasApplication = null;
 

--- a/src/Numbers/Filter/OwnedNumbers.php
+++ b/src/Numbers/Filter/OwnedNumbers.php
@@ -30,35 +30,17 @@ class OwnedNumbers implements FilterInterface
         'features' => 'string'
     ];
 
-    /**
-     * @var string
-     */
-    protected $applicationId;
+    protected ?string $applicationId = null;
 
-    /**
-     * @var string
-     */
-    protected $country;
+    protected ?string $country = null;
 
-    /**
-     * @var bool
-     */
-    protected $hasApplication;
+    protected ?bool $hasApplication = null;
 
-    /**
-     * @var int
-     */
-    protected $pageIndex = 1;
+    protected int $pageIndex = 1;
 
-    /**
-     * @var string
-     */
-    protected $pattern;
+    protected string $pattern;
 
-    /**
-     * @var int
-     */
-    protected $searchPattern = 0;
+    protected int $searchPattern = 0;
 
     protected int $pageSize = 10;
 
@@ -167,9 +149,6 @@ class OwnedNumbers implements FilterInterface
         return $this->pageIndex;
     }
 
-    /**
-     * @return $this
-     */
     public function setPageIndex(int $pageIndex): self
     {
         $this->pageIndex = $pageIndex;
@@ -182,9 +161,6 @@ class OwnedNumbers implements FilterInterface
         return $this->pattern;
     }
 
-    /**
-     * @return $this
-     */
     public function setPattern(string $pattern): self
     {
         $this->pattern = $pattern;
@@ -197,9 +173,6 @@ class OwnedNumbers implements FilterInterface
         return $this->searchPattern;
     }
 
-    /**
-     * @return $this
-     */
     public function setSearchPattern(int $searchPattern): self
     {
         $this->searchPattern = $searchPattern;
@@ -212,9 +185,6 @@ class OwnedNumbers implements FilterInterface
         return $this->pageSize;
     }
 
-    /**
-     * @return $this
-     */
     public function setPageSize(int $pageSize): self
     {
         $this->pageSize = $pageSize;
@@ -227,9 +197,6 @@ class OwnedNumbers implements FilterInterface
         return $this->applicationId;
     }
 
-    /**
-     * @return $this
-     */
     public function setApplicationId(string $applicationId): self
     {
         $this->applicationId = $applicationId;
@@ -242,9 +209,6 @@ class OwnedNumbers implements FilterInterface
         return $this->hasApplication;
     }
 
-    /**
-     * @return $this
-     */
     public function setHasApplication(bool $hasApplication): self
     {
         $this->hasApplication = $hasApplication;

--- a/src/Numbers/Number.php
+++ b/src/Numbers/Number.php
@@ -15,14 +15,12 @@ use Vonage\Entity\JsonSerializableTrait;
 use Vonage\Entity\JsonUnserializableInterface;
 use Vonage\Entity\NoRequestResponseTrait;
 
-use function get_class;
 use function in_array;
 use function is_null;
 use function json_decode;
 use function json_last_error;
 use function preg_match;
 use function stripos;
-use function strpos;
 use function trigger_error;
 
 class Number implements EntityInterface, JsonSerializableInterface, JsonUnserializableInterface, ArrayHydrateInterface, \Stringable
@@ -51,10 +49,7 @@ class Number implements EntityInterface, JsonSerializableInterface, JsonUnserial
     public const ENDPOINT_VXML = 'vxml';
     public const ENDPOINT_APP = 'app';
 
-    /**
-     * @var array
-     */
-    protected $data = [];
+    protected array $data = [];
 
     public function __construct($number = null, $country = null)
     {
@@ -62,39 +57,36 @@ class Number implements EntityInterface, JsonSerializableInterface, JsonUnserial
         $this->data['country'] = $country;
     }
 
-    public function getId()
+    public function getId(): mixed
     {
         return $this->fromData('msisdn');
     }
 
-    public function getMsisdn()
+    public function getMsisdn(): mixed
     {
         return $this->getId();
     }
 
-    public function getNumber()
+    public function getNumber(): mixed
     {
         return $this->getId();
     }
 
-    public function getCountry()
+    public function getCountry(): mixed
     {
         return $this->fromData('country');
     }
 
-    public function getType()
+    public function getType(): mixed
     {
         return $this->fromData('type');
     }
 
-    public function getCost()
+    public function getCost(): mixed
     {
         return $this->fromData('cost');
     }
 
-    /**
-     * @param $feature
-     */
     public function hasFeature($feature): bool
     {
         if (!isset($this->data['features'])) {
@@ -104,15 +96,11 @@ class Number implements EntityInterface, JsonSerializableInterface, JsonUnserial
         return in_array($feature, $this->data['features'], true);
     }
 
-    public function getFeatures()
+    public function getFeatures(): mixed
     {
         return $this->fromData('features');
     }
 
-    /**
-     * @param $type
-     * @param $url
-     */
     public function setWebhook($type, $url): self
     {
         if (!in_array($type, [self::WEBHOOK_MESSAGE, self::WEBHOOK_VOICE_STATUS], true)) {
@@ -123,26 +111,16 @@ class Number implements EntityInterface, JsonSerializableInterface, JsonUnserial
         return $this;
     }
 
-    /**
-     * @param $type
-     */
     public function getWebhook($type)
     {
         return $this->fromData($type);
     }
 
-    /**
-     * @param $type
-     */
     public function hasWebhook($type): bool
     {
         return isset($this->data[$type]);
     }
 
-    /**
-     * @param $endpoint
-     * @param $type
-     */
     public function setVoiceDestination($endpoint, $type = null): self
     {
         if (is_null($type)) {
@@ -159,9 +137,6 @@ class Number implements EntityInterface, JsonSerializableInterface, JsonUnserial
         return $this;
     }
 
-    /**
-     * @param $endpoint
-     */
     protected function autoType($endpoint): string
     {
         if ($endpoint instanceof Application) {
@@ -183,22 +158,16 @@ class Number implements EntityInterface, JsonSerializableInterface, JsonUnserial
         return self::ENDPOINT_TEL;
     }
 
-    public function getVoiceDestination()
+    public function getVoiceDestination(): mixed
     {
         return $this->fromData('voiceCallbackValue');
     }
 
-    /**
-     * @return mixed|null
-     */
-    public function getVoiceType()
+    public function getVoiceType(): mixed
     {
         return $this->data['voiceCallbackType'] ?? null;
     }
 
-    /**
-     * @param $name
-     */
     protected function fromData($name)
     {
         if (!isset($this->data[$name])) {
@@ -232,11 +201,8 @@ class Number implements EntityInterface, JsonSerializableInterface, JsonUnserial
         $this->data = $data;
     }
 
-    /**
-     * @return array|mixed
-     */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -264,17 +230,11 @@ class Number implements EntityInterface, JsonSerializableInterface, JsonUnserial
         return $json;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return (string)$this->getId();
     }
 
-    /**
-     * @return $this
-     */
     public function setAppId(string $appId): self
     {
         $this->data['messagesCallbackType'] = self::ENDPOINT_APP;

--- a/src/SMS/Collection.php
+++ b/src/SMS/Collection.php
@@ -9,10 +9,7 @@ use Iterator;
 
 class Collection implements Countable, Iterator
 {
-    /**
-     * @var int
-     */
-    protected $current = 0;
+    protected int $current = 0;
 
     /**
      * @param array<string, int|array<string, mixed>> $data

--- a/src/Secrets/Secret.php
+++ b/src/Secrets/Secret.php
@@ -8,15 +8,9 @@ use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 
 class Secret implements ArrayHydrateInterface
 {
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $createdAt;
+    protected DateTimeImmutable $createdAt;
 
-    /**
-     * @var string
-     */
-    protected $id;
+    protected string $id;
 
     public function __construct(array $data = [])
     {

--- a/src/Subaccount/ClientFactory.php
+++ b/src/Subaccount/ClientFactory.php
@@ -4,8 +4,6 @@ namespace Vonage\Subaccount;
 
 use Psr\Container\ContainerInterface;
 use Vonage\Client\APIResource;
-use Vonage\Client\Credentials\Handler\BasicHandler;
-use Vonage\Client\Credentials\Handler\KeypairHandler;
 
 class ClientFactory
 {

--- a/src/Subaccount/Filter/SubaccountFilter.php
+++ b/src/Subaccount/Filter/SubaccountFilter.php
@@ -46,7 +46,7 @@ class SubaccountFilter implements FilterInterface
         }
     }
 
-    public function getQuery()
+    public function getQuery(): array
     {
         $data = [];
 

--- a/src/Subaccount/Request/NumberTransferRequest.php
+++ b/src/Subaccount/Request/NumberTransferRequest.php
@@ -12,7 +12,8 @@ class NumberTransferRequest implements ArrayHydrateInterface
         protected string $to,
         protected string $number,
         protected string $country
-    ) {}
+    ) {
+    }
 
     public function setFrom(string $from): self
     {

--- a/src/Subaccount/Request/TransferBalanceRequest.php
+++ b/src/Subaccount/Request/TransferBalanceRequest.php
@@ -23,7 +23,7 @@ class TransferBalanceRequest implements ArrayHydrateInterface
     {
         $this->from = $from;
 
-        return $this; 
+        return $this;
     }
 
     public function getTo(): string
@@ -35,7 +35,7 @@ class TransferBalanceRequest implements ArrayHydrateInterface
     {
         $this->to = $to;
 
-        return $this; 
+        return $this;
     }
 
     public function getAmount(): string
@@ -47,7 +47,7 @@ class TransferBalanceRequest implements ArrayHydrateInterface
     {
         $this->amount = $amount;
 
-        return $this; 
+        return $this;
     }
 
     public function getReference(): string
@@ -59,7 +59,7 @@ class TransferBalanceRequest implements ArrayHydrateInterface
     {
         $this->reference = $reference;
 
-        return $this; 
+        return $this;
     }
 
     public function getApiKey(): string
@@ -71,7 +71,7 @@ class TransferBalanceRequest implements ArrayHydrateInterface
     {
         $this->apiKey = $apiKey;
 
-        return $this; 
+        return $this;
     }
 
     public function fromArray(array $data): static

--- a/src/Subaccount/Request/TransferCreditRequest.php
+++ b/src/Subaccount/Request/TransferCreditRequest.php
@@ -23,7 +23,7 @@ class TransferCreditRequest implements ArrayHydrateInterface
     {
         $this->from = $from;
 
-        return $this; 
+        return $this;
     }
 
     public function getTo(): string
@@ -35,7 +35,7 @@ class TransferCreditRequest implements ArrayHydrateInterface
     {
         $this->to = $to;
 
-        return $this; 
+        return $this;
     }
 
     public function getAmount(): string
@@ -47,7 +47,7 @@ class TransferCreditRequest implements ArrayHydrateInterface
     {
         $this->amount = $amount;
 
-        return $this; 
+        return $this;
     }
 
     public function getReference(): string
@@ -59,7 +59,7 @@ class TransferCreditRequest implements ArrayHydrateInterface
     {
         $this->reference = $reference;
 
-        return $this; 
+        return $this;
     }
 
     public function getApiKey(): string
@@ -71,7 +71,7 @@ class TransferCreditRequest implements ArrayHydrateInterface
     {
         $this->apiKey = $apiKey;
 
-        return $this; 
+        return $this;
     }
 
     public function fromArray(array $data): static

--- a/src/Users/Client.php
+++ b/src/Users/Client.php
@@ -14,7 +14,6 @@ use Vonage\Entity\Hydrator\HydratorInterface;
 use Vonage\Entity\IterableAPICollection;
 use Vonage\Entity\Filter\FilterInterface;
 
-use Vonage\Users\Filter\UserFilter;
 use function is_null;
 
 class Client implements ClientAwareInterface, APIClient
@@ -34,7 +33,7 @@ class Client implements ClientAwareInterface, APIClient
     {
         if (is_null($filter)) {
             $filter = new EmptyFilter();
-        } 
+        }
 
         $response = $this->api->search($filter);
         $response->setHydrator($this->hydrator);

--- a/src/Verify/Check.php
+++ b/src/Verify/Check.php
@@ -19,7 +19,7 @@ class Check
     {
     }
 
-    public function getCode()
+    public function getCode(): mixed
     {
         return $this->data['code'];
     }

--- a/src/Verify/Client.php
+++ b/src/Verify/Client.php
@@ -48,14 +48,12 @@ class Client implements ClientAwareInterface, APIClient
     }
 
     /**
-     * @param string|array|Verification|Request $verification
-     *
      * @throws ClientExceptionInterface
      * @throws ClientException\Exception
      * @throws ClientException\Request
      * @throws ClientException\Server
      */
-    public function start($verification): Verification
+    public function start(Request|Verification|array|string $verification): Verification
     {
         if (is_array($verification)) {
             trigger_error(
@@ -104,14 +102,12 @@ class Client implements ClientAwareInterface, APIClient
     }
 
     /**
-     * @param string|Verification $verification
-     *
      * @throws ClientExceptionInterface
      * @throws ClientException\Exception
      * @throws ClientException\Request
      * @throws ClientException\Server
      */
-    public function search($verification)
+    public function search(Verification|string $verification)
     {
         if ($verification instanceof Verification) {
             trigger_error(
@@ -177,14 +173,12 @@ class Client implements ClientAwareInterface, APIClient
     }
 
     /**
-     * @param string|array|Verification $verification
-     *
      * @throws ClientExceptionInterface
      * @throws ClientException\Exception
      * @throws ClientException\Request
      * @throws ClientException\Server
      */
-    public function check($verification, string $code, string $ip = null): Verification
+    public function check(Verification|array|string $verification, string $code, string $ip = null): Verification
     {
         if (is_array($verification)) {
             trigger_error(
@@ -254,7 +248,6 @@ class Client implements ClientAwareInterface, APIClient
     }
 
     /**
-     * @param string|array|Verification $verification
      * @param string $cmd Next command to execute, must be `cancel` or `trigger_next_event`
      *
      * @throws ClientExceptionInterface
@@ -262,7 +255,7 @@ class Client implements ClientAwareInterface, APIClient
      * @throws ClientException\Request
      * @throws ClientException\Server
      */
-    protected function control($verification, string $cmd): Verification
+    protected function control(Verification|array|string $verification, string $cmd): Verification
     {
         if (is_array($verification)) {
             trigger_error(
@@ -293,13 +286,10 @@ class Client implements ClientAwareInterface, APIClient
     }
 
     /**
-     * @param $verification
-     * @param $data
-     *
      * @throws ClientException\Request
      * @throws ClientException\Server
      */
-    protected function checkError($verification, $data)
+    protected function checkError($verification, array $data)
     {
         if (!isset($data['status'])) {
             $e = new ClientException\Request('unexpected response from API');
@@ -344,9 +334,6 @@ class Client implements ClientAwareInterface, APIClient
         throw $e;
     }
 
-    /**
-     * @param bool $replace
-     */
     protected function processReqRes(
         Verification $verification,
         RequestInterface $req,
@@ -370,8 +357,6 @@ class Client implements ClientAwareInterface, APIClient
 
     /**
      * Creates a verification object from a variety of sources
-     *
-     * @param $verification
      */
     protected function createVerification($verification): Verification
     {

--- a/src/Verify/ClientFactory.php
+++ b/src/Verify/ClientFactory.php
@@ -10,7 +10,6 @@ use Vonage\Client\Credentials\Handler\TokenBodyHandler;
 
 class ClientFactory
 {
-
     public function __invoke(ContainerInterface $container): Client
     {
         /** @var APIResource $api */

--- a/src/Verify/ExceptionErrorHandler.php
+++ b/src/Verify/ExceptionErrorHandler.php
@@ -19,7 +19,7 @@ class ExceptionErrorHandler
      * @todo This should throw a Server exception instead of Request, fix next major release
      * @throws Request
      */
-    public function __invoke(ResponseInterface $response, RequestInterface $request)
+    public function __invoke(ResponseInterface $response, RequestInterface $request): void
     {
         $data = json_decode($response->getBody()->getContents(), true);
         $response->getBody()->rewind();

--- a/src/Verify/RequestPSD2.php
+++ b/src/Verify/RequestPSD2.php
@@ -23,38 +23,24 @@ class RequestPSD2 implements ArrayHydrateInterface
     public const WORKFLOW_SMS = 6;
     public const WORKFLOW_TTS = 7;
 
-    /**
-     * @var string
-     */
-    protected $country;
+    protected ?string $country = null;
 
-    /**
-     * @var int
-     */
-    protected $codeLength;
+    protected ?int $codeLength = null;
 
-    /**
-     * @var string
-     */
-    protected $locale;
+    protected ?string $locale = null;
 
-    /**
-     * @var int
-     */
-    protected $pinExpiry;
+    protected ?int $pinExpiry = null;
 
-    /**
-     * @var int
-     */
-    protected $nextEventWait;
+    protected ?int $nextEventWait = null;
 
-    /**
-     * @var int
-     */
-    protected $workflowId;
+    protected ?int $workflowId = null;
 
-    public function __construct(protected string $number, protected string $payee, protected string $amount, int $workflowId = null)
-    {
+    public function __construct(
+        protected string $number,
+        protected string $payee,
+        protected string $amount,
+        int $workflowId = null
+    ) {
         if ($workflowId) {
             $this->setWorkflowId($workflowId);
         }
@@ -65,9 +51,6 @@ class RequestPSD2 implements ArrayHydrateInterface
         return $this->country;
     }
 
-    /**
-     * @return $this
-     */
     public function setCountry(string $country): self
     {
         if (strlen($country) !== 2) {
@@ -84,9 +67,6 @@ class RequestPSD2 implements ArrayHydrateInterface
         return $this->codeLength;
     }
 
-    /**
-     * @return $this
-     */
     public function setCodeLength(int $codeLength): self
     {
         if ($codeLength !== 4 || $codeLength !== 6) {
@@ -118,9 +98,6 @@ class RequestPSD2 implements ArrayHydrateInterface
         return $this->pinExpiry;
     }
 
-    /**
-     * @return $this
-     */
     public function setPinExpiry(int $pinExpiry): self
     {
         if ($pinExpiry < 60 || $pinExpiry > 3600) {
@@ -137,9 +114,6 @@ class RequestPSD2 implements ArrayHydrateInterface
         return $this->nextEventWait;
     }
 
-    /**
-     * @return $this
-     */
     public function setNextEventWait(int $nextEventWait): self
     {
         if ($nextEventWait < 60 || $nextEventWait > 3600) {

--- a/src/Verify/Verification.php
+++ b/src/Verify/Verification.php
@@ -48,14 +48,14 @@ class Verification implements VerificationInterface, Serializable, ArrayHydrateI
     public const EXPIRED = 'EXPIRED';
     public const IN_PROGRESS = 'IN PROGRESS';
 
-    protected $dirty = true;
+    protected bool $dirty = true;
 
     /**
      * @deprecated Use the Vonage\Verify\Client instead to interact with the API
      *
      * @var Client;
      */
-    protected $client;
+    protected Client $client;
 
     /**
      * Verification constructor.

--- a/src/Voice/Call.php
+++ b/src/Voice/Call.php
@@ -14,65 +14,29 @@ use function array_key_exists;
 
 class Call implements ArrayHydrateInterface
 {
-    /**
-     * @var string
-     */
-    protected $conversationUuid;
+    protected ?string $conversationUuid = null;
 
-    /**
-     * @var string
-     */
-    protected $direction;
+    protected ?string $direction = null;
 
-    /**
-     * @var string
-     */
-    protected $duration;
+    protected ?string $duration = null;
 
-    /**
-     * @var DateTime
-     */
-    protected $endTime;
+    protected ?DateTime $endTime = null;
 
-    /**
-     * @var EndpointInterface
-     */
-    protected $from;
+    protected ?EndpointInterface $from = null;
 
-    /**
-     * @var string
-     */
-    protected $network;
+    protected ?string $network = null;
 
-    /**
-     * @var string
-     */
-    protected $price;
+    protected ?string $price = null;
 
-    /**
-     * @var string
-     */
-    protected $rate;
+    protected ?string $rate = null;
 
-    /**
-     * @var DateTime
-     */
-    protected $startTime;
+    protected ?DateTime $startTime = null;
 
-    /**
-     * @var string
-     */
-    protected $status;
+    protected ?string $status = null;
 
-    /**
-     * @var EndpointInterface
-     */
-    protected $to;
+    protected ?EndpointInterface $to = null;
 
-    /**
-     * @var string
-     */
-    protected $uuid;
+    protected ?string $uuid = null;
 
     /**
      * @throws Exception

--- a/src/Voice/Endpoint/Phone.php
+++ b/src/Voice/Endpoint/Phone.php
@@ -8,15 +8,9 @@ use function array_key_exists;
 
 class Phone implements EndpointInterface
 {
-    /**
-     * @var ?string
-     */
-    protected $ringbackTone;
+    protected ?string $ringbackTone = null;
 
-    /**
-     * @var ?string
-     */
-    protected $url;
+    protected ?string $url = null;
 
     public function __construct(protected string $id, protected ?string $dtmfAnswer = null)
     {

--- a/src/Voice/Endpoint/SIP.php
+++ b/src/Voice/Endpoint/SIP.php
@@ -9,7 +9,7 @@ class SIP implements EndpointInterface
     /**
      * @var array<string, string>
      */
-    protected $headers = [];
+    protected array $headers = [];
 
     public function __construct(protected string $id, array $headers = [])
     {

--- a/src/Voice/Endpoint/Websocket.php
+++ b/src/Voice/Endpoint/Websocket.php
@@ -11,15 +11,12 @@ class Websocket implements EndpointInterface
     public const TYPE_16000 = 'audio/116;rate=16000';
     public const TYPE_8000 = 'audio/116;rate=8000';
 
-    /**
-     * @var string
-     */
-    protected $contentType;
+    protected string $contentType;
 
     /**
      * @var array<string, string>
      */
-    protected $headers = [];
+    protected array $headers = [];
 
     public function __construct(protected string $id, string $rate = self::TYPE_8000, array $headers = [])
     {
@@ -78,9 +75,6 @@ class Websocket implements EndpointInterface
         return $this->contentType;
     }
 
-    /**
-     * @return $this
-     */
     public function setContentType(string $contentType): self
     {
         $this->contentType = $contentType;
@@ -93,9 +87,6 @@ class Websocket implements EndpointInterface
         return $this->headers;
     }
 
-    /**
-     * @return $this
-     */
     public function addHeader(string $key, string $value): self
     {
         $this->headers[$key] = $value;
@@ -103,9 +94,6 @@ class Websocket implements EndpointInterface
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setHeaders(array $headers): self
     {
         $this->headers = $headers;

--- a/src/Voice/Filter/VoiceFilter.php
+++ b/src/Voice/Filter/VoiceFilter.php
@@ -26,40 +26,19 @@ class VoiceFilter implements FilterInterface
     public const ORDER_ASC = 'asc';
     public const ORDER_DESC = 'desc';
 
-    /**
-     * @var string
-     */
-    protected $status;
+    protected ?string $status = null;
 
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $dateStart;
+    protected ?DateTimeImmutable $dateStart = null;
 
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $dateEnd;
+    protected ?DateTimeImmutable $dateEnd = null;
 
-    /**
-     * @var int
-     */
-    protected $pageSize = 10;
+    protected int $pageSize = 10;
 
-    /**
-     * @var int
-     */
-    protected $recordIndex = 0;
+    protected int $recordIndex = 0;
 
-    /**
-     * @var string
-     */
-    protected $order = 'asc';
+    protected string $order = 'asc';
 
-    /**
-     * @var string
-     */
-    protected $conversationUUID;
+    protected ?string $conversationUUID = null;
 
     public function getQuery(): array
     {

--- a/src/Voice/NCCO/Action/Connect.php
+++ b/src/Voice/NCCO/Action/Connect.php
@@ -20,7 +20,7 @@ class Connect implements ActionInterface
 
     protected int $timeout = 0;
     protected int $limit = 0;
-    protected $machineDetection = '';
+    protected string $machineDetection = '';
     protected ?Webhook $eventWebhook = null;
     protected ?string $ringbackTone = '';
     protected ?AdvancedMachineDetection $advancedMachineDetection = null;
@@ -34,11 +34,8 @@ class Connect implements ActionInterface
         return new Connect($endpoint);
     }
 
-    /**
-     * @return array|mixed
-     */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toNCCOArray();
     }
@@ -114,9 +111,6 @@ class Connect implements ActionInterface
         return $this->eventType;
     }
 
-    /**
-     * @return $this
-     */
     public function setEventType(string $eventType): self
     {
         if ($eventType !== self::EVENT_TYPE_SYNCHRONOUS) {
@@ -133,9 +127,6 @@ class Connect implements ActionInterface
         return $this->timeout;
     }
 
-    /**
-     * @return $this
-     */
     public function setTimeout(int $timeout): self
     {
         $this->timeout = $timeout;
@@ -148,9 +139,6 @@ class Connect implements ActionInterface
         return $this->limit;
     }
 
-    /**
-     * @return $this
-     */
     public function setLimit(int $limit): self
     {
         $this->limit = $limit;
@@ -163,9 +151,6 @@ class Connect implements ActionInterface
         return $this->machineDetection;
     }
 
-    /**
-     * @return $this
-     */
     public function setMachineDetection(string $machineDetection): self
     {
         if (
@@ -185,9 +170,6 @@ class Connect implements ActionInterface
         return $this->eventWebhook;
     }
 
-    /**
-     * @return $this
-     */
     public function setEventWebhook(Webhook $eventWebhook): self
     {
         $this->eventWebhook = $eventWebhook;
@@ -200,9 +182,6 @@ class Connect implements ActionInterface
         return $this->ringbackTone;
     }
 
-    /**
-     * @return $this
-     */
     public function setRingbackTone(string $ringbackTone): self
     {
         $this->ringbackTone = $ringbackTone;

--- a/src/Voice/NCCO/Action/Conversation.php
+++ b/src/Voice/NCCO/Action/Conversation.php
@@ -13,40 +13,25 @@ use function is_null;
 
 class Conversation implements ActionInterface
 {
-    /**
-     * @var ?string
-     */
-    protected $musicOnHoldUrl;
+    protected ?string $musicOnHoldUrl = null;
 
-    /**
-     * @var bool
-     */
-    protected $startOnEnter;
+    protected ?bool $startOnEnter = null;
 
-    /**
-     * @var bool
-     */
-    protected $endOnExit;
+    protected ?bool $endOnExit = null;
 
-    /**
-     * @var bool
-     */
-    protected $record;
+    protected ?bool $record = null;
 
     /**
      * @var ?array<string>
      */
-    protected $canSpeak;
+    protected ?array $canSpeak = null;
 
     /**
      * @var ?array<string>
      */
-    protected $canHear;
+    protected ?array $canHear = null;
 
-    /**
-     * @var Webhook
-     */
-    protected $eventWebhook;
+    protected ?Webhook $eventWebhook = null;
 
     public function __construct(protected string $name)
     {
@@ -107,9 +92,6 @@ class Conversation implements ActionInterface
         return $this->record;
     }
 
-    /**
-     * @return $this
-     */
     public function setRecord(bool $record): self
     {
         $this->record = $record;
@@ -127,8 +109,6 @@ class Conversation implements ActionInterface
 
     /**
      * @param array<string> $canSpeak
-     *
-     * @return Conversation
      */
     public function setCanSpeak(array $canSpeak): self
     {
@@ -137,9 +117,6 @@ class Conversation implements ActionInterface
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function addCanSpeak(string $uuid): self
     {
         $this->canSpeak[] = $uuid;
@@ -157,8 +134,6 @@ class Conversation implements ActionInterface
 
     /**
      * @param array<string> $canHear
-     *
-     * @return Conversation
      */
     public function setCanHear(array $canHear): self
     {
@@ -167,9 +142,6 @@ class Conversation implements ActionInterface
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function addCanHear(string $uuid): self
     {
         $this->canHear[] = $uuid;

--- a/src/Voice/NCCO/Action/Input.php
+++ b/src/Voice/NCCO/Action/Input.php
@@ -14,65 +14,32 @@ use function is_null;
 
 class Input implements ActionInterface
 {
-    /**
-     * @var int
-     */
-    protected $dtmfTimeout;
+    protected ?int $dtmfTimeout = null;
+
+    protected ?int $dtmfMaxDigits = null;
+
+    protected ?bool $dtmfSubmitOnHash = null;
+
+    protected ?string $speechUUID = null;
+
+    protected ?int $speechEndOnSilence = null;
+
+    protected ?string $speechLanguage = null;
 
     /**
-     * @var int
+     * @var ?array<string>
      */
-    protected $dtmfMaxDigits;
+    protected ?array $speechContext = null;
 
-    /**
-     * @var bool
-     */
-    protected $dtmfSubmitOnHash;
+    protected ?int $speechStartTimeout = null;
 
-    /**
-     * @var ?string
-     */
-    protected $speechUUID;
+    protected ?int $speechMaxDuration = null;
 
-    /**
-     * @var int
-     */
-    protected $speechEndOnSilence;
+    protected ?Webhook $eventWebhook = null;
 
-    /**
-     * @var string
-     */
-    protected $speechLanguage;
+    protected bool $enableSpeech = false;
 
-    /**
-     * @var array<string>
-     */
-    protected $speechContext;
-
-    /**
-     * @var ?int
-     */
-    protected $speechStartTimeout;
-
-    /**
-     * @var int
-     */
-    protected $speechMaxDuration;
-
-    /**
-     * @var ?Webhook
-     */
-    protected $eventWebhook;
-
-    /**
-     * @var bool
-     */
-    protected $enableSpeech = false;
-
-    /**
-     * @var bool
-     */
-    protected $enableDtmf = false;
+    protected bool $enableDtmf = false;
 
     /**
      * @param array<array, mixed> $data
@@ -255,9 +222,6 @@ class Input implements ActionInterface
         return $this->dtmfMaxDigits;
     }
 
-    /**
-     * @return $this
-     */
     public function setDtmfMaxDigits(int $dtmfMaxDigits): self
     {
         $this->setEnableDtmf(true);
@@ -271,9 +235,6 @@ class Input implements ActionInterface
         return $this->dtmfSubmitOnHash;
     }
 
-    /**
-     * @return $this
-     */
     public function setDtmfSubmitOnHash(bool $dtmfSubmitOnHash): self
     {
         $this->setEnableDtmf(true);
@@ -287,9 +248,6 @@ class Input implements ActionInterface
         return $this->speechUUID;
     }
 
-    /**
-     * @return $this
-     */
     public function setSpeechUUID(string $speechUUID): self
     {
         $this->setEnableSpeech(true);
@@ -303,9 +261,6 @@ class Input implements ActionInterface
         return $this->speechEndOnSilence;
     }
 
-    /**
-     * @return $this
-     */
     public function setSpeechEndOnSilence(int $speechEndOnSilence): self
     {
         $this->setEnableSpeech(true);
@@ -319,9 +274,6 @@ class Input implements ActionInterface
         return $this->speechLanguage;
     }
 
-    /**
-     * @return $this
-     */
     public function setSpeechLanguage(string $speechLanguage): self
     {
         $this->setEnableSpeech(true);
@@ -331,7 +283,7 @@ class Input implements ActionInterface
     }
 
     /**
-     * @return array<string>
+     * @return ?array<string>
      */
     public function getSpeechContext(): ?array
     {
@@ -340,8 +292,6 @@ class Input implements ActionInterface
 
     /**
      * @param array<string> $speechContext Array of words to help with speech recognition
-     *
-     * @return Input
      */
     public function setSpeechContext(array $speechContext): self
     {
@@ -356,9 +306,6 @@ class Input implements ActionInterface
         return $this->speechStartTimeout;
     }
 
-    /**
-     * @return $this
-     */
     public function setSpeechStartTimeout(int $speechStartTimeout): self
     {
         $this->setEnableSpeech(true);
@@ -400,9 +347,6 @@ class Input implements ActionInterface
         return $this->enableSpeech;
     }
 
-    /**
-     * @return $this
-     */
     public function setEnableSpeech(bool $enableSpeech): Input
     {
         $this->enableSpeech = $enableSpeech;
@@ -415,9 +359,6 @@ class Input implements ActionInterface
         return $this->enableDtmf;
     }
 
-    /**
-     * @return $this
-     */
     public function setEnableDtmf(bool $enableDtmf): Input
     {
         $this->enableDtmf = $enableDtmf;

--- a/src/Voice/NCCO/Action/Record.php
+++ b/src/Voice/NCCO/Action/Record.php
@@ -21,43 +21,28 @@ class Record implements ActionInterface
     /**
      * @var string Record::FORMAT_*
      */
-    protected $format = 'mp3';
+    protected string $format = 'mp3';
 
     /**
-     * @var string Record::SPLIT
+     * @var ?string Record::SPLIT
      */
-    protected $split;
+    protected ?string $split = null;
+
+    protected ?int $channels = null;
+
+    protected ?int $endOnSilence = null;
 
     /**
-     * @var int
+     * @var ?string '*'|'#'|1'|2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'|'0'
      */
-    protected $channels;
-
-    /**
-     * @var int
-     */
-    protected $endOnSilence;
-
-    /**
-     * @var string '*'|'#'|1'|2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'|'0'
-     */
-    protected $endOnKey;
+    protected ?string $endOnKey = null;
 
     protected ?int $timeOut = null;
 
-    /**
-     * @var bool
-     */
-    protected $beepStart = false;
+    protected bool $beepStart = false;
 
-    /**
-     * @var Webhook
-     */
-    protected $eventWebhook;
+    protected ?Webhook $eventWebhook = null;
 
-    /**
-     * @return static
-     */
     public static function factory(array $data): self
     {
         $action = new self();
@@ -166,9 +151,6 @@ class Record implements ActionInterface
         return $this->format;
     }
 
-    /**
-     * @return $this
-     */
     public function setFormat(string $format): self
     {
         $this->format = $format;
@@ -181,9 +163,6 @@ class Record implements ActionInterface
         return $this->split;
     }
 
-    /**
-     * @return $this
-     */
     public function setSplit(string $split): self
     {
         if ($split !== 'conversation') {
@@ -200,9 +179,6 @@ class Record implements ActionInterface
         return $this->endOnKey;
     }
 
-    /**
-     * @return $this
-     */
     public function setEndOnKey(string $endOnKey): self
     {
         $match = preg_match('/^[*#0-9]$/', $endOnKey);
@@ -221,9 +197,6 @@ class Record implements ActionInterface
         return $this->eventWebhook;
     }
 
-    /**
-     * @return $this
-     */
     public function setEventWebhook(Webhook $eventWebhook): self
     {
         $this->eventWebhook = $eventWebhook;
@@ -236,9 +209,6 @@ class Record implements ActionInterface
         return $this->endOnSilence;
     }
 
-    /**
-     * @return $this
-     */
     public function setEndOnSilence(int $endOnSilence): self
     {
         if ($endOnSilence > 10 || $endOnSilence < 3) {
@@ -255,9 +225,6 @@ class Record implements ActionInterface
         return $this->timeOut;
     }
 
-    /**
-     * @return $this
-     */
     public function setTimeout(int $timeOut): self
     {
         if ($timeOut > 7200 || $timeOut < 3) {
@@ -274,9 +241,6 @@ class Record implements ActionInterface
         return $this->beepStart;
     }
 
-    /**
-     * @return $this
-     */
     public function setBeepStart(bool $beepStart): self
     {
         $this->beepStart = $beepStart;
@@ -289,9 +253,6 @@ class Record implements ActionInterface
         return $this->channels;
     }
 
-    /**
-     * @return $this
-     */
     public function setChannels(int $channels): self
     {
         if ($channels > 32) {

--- a/src/Voice/NCCO/Action/Stream.php
+++ b/src/Voice/NCCO/Action/Stream.php
@@ -10,20 +10,11 @@ use function is_null;
 
 class Stream implements ActionInterface
 {
-    /**
-     * @var bool
-     */
-    protected $bargeIn;
+    protected ?bool $bargeIn = null;
 
-    /**
-     * @var float
-     */
-    protected $level;
+    protected ?float $level = null;
 
-    /**
-     * @var int
-     */
-    protected $loop;
+    protected ?int $loop = null;
 
     public function __construct(protected string $streamUrl)
     {

--- a/src/Voice/NCCO/NCCO.php
+++ b/src/Voice/NCCO/NCCO.php
@@ -13,11 +13,8 @@ class NCCO implements ArrayHydrateInterface, JsonSerializable
     /**
      * @var array<ActionInterface>
      */
-    protected $actions = [];
+    protected array $actions = [];
 
-    /**
-     * @return $this
-     */
     public function addAction(ActionInterface $action): self
     {
         $this->actions[] = $action;

--- a/src/Voice/NCCO/NCCOFactory.php
+++ b/src/Voice/NCCO/NCCOFactory.php
@@ -17,10 +17,7 @@ use Vonage\Voice\NCCO\Action\Talk;
 
 class NCCOFactory
 {
-    /**
-     * @param $data
-     */
-    public function build($data): ActionInterface
+    public function build(array $data): ActionInterface
     {
         switch ($data['action']) {
             case 'connect':

--- a/src/Voice/VoiceObjects/AdvancedMachineDetection.php
+++ b/src/Voice/VoiceObjects/AdvancedMachineDetection.php
@@ -104,9 +104,11 @@ class AdvancedMachineDetection implements ArrayHydrateInterface
             return false;
         }
 
-        if ($this->isValidBehaviour($data['behaviour'])
+        if (
+            $this->isValidBehaviour($data['behaviour'])
                && $this->isValidMode($data['mode'])
-               && $this->isValidTimeout($data['beep_timeout'])) {
+               && $this->isValidTimeout($data['beep_timeout'])
+        ) {
             return true;
         };
 

--- a/src/Voice/Webhook/Answer.php
+++ b/src/Voice/Webhook/Answer.php
@@ -6,25 +6,13 @@ namespace Vonage\Voice\Webhook;
 
 class Answer
 {
-    /**
-     * @var string
-     */
-    protected $conversationUuid;
+    protected ?string $conversationUuid = null;
 
-    /**
-     * @var string
-     */
-    protected $from;
+    protected ?string $from = null;
 
-    /**
-     * @var string
-     */
-    protected $to;
+    protected ?string $to = null;
 
-    /**
-     * @var string
-     */
-    protected $uuid;
+    protected ?string $uuid = null;
 
     public function __construct(array $event)
     {

--- a/src/Voice/Webhook/Error.php
+++ b/src/Voice/Webhook/Error.php
@@ -9,20 +9,11 @@ use Exception;
 
 class Error
 {
-    /**
-     * @var string
-     */
-    protected $conversationUuid;
+    protected ?string $conversationUuid = null;
 
-    /**
-     * @var string
-     */
-    protected $reason;
+    protected ?string $reason = null;
 
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $timestamp;
+    protected ?DateTimeImmutable $timestamp = null;
 
     /**
      * @throws Exception

--- a/src/Voice/Webhook/Event.php
+++ b/src/Voice/Webhook/Event.php
@@ -26,75 +26,33 @@ class Event
     public const STATUS_TIMEOUT = 'timeout';
     public const STATUS_COMPLETED = 'completed';
 
-    /**
-     * @var string
-     */
-    protected $conversationUuid;
+    protected ?string $conversationUuid = null;
 
-    /**
-     * @var string
-     */
-    protected $detail;
+    protected ?string $detail = null;
 
-    /**
-     * @var string
-     */
-    protected $direction;
+    protected ?string $direction = null;
 
-    /**
-     * @var ?string
-     */
-    protected $duration;
+    protected ?string $duration = null;
 
-    /**
-     * @var ?DateTimeImmutable
-     */
-    protected $endTime;
+    protected ?DateTimeImmutable $endTime = null;
 
-    /**
-     * @var string
-     */
-    protected $from;
+    protected ?string $from = null;
 
-    /**
-     * @var ?string
-     */
-    protected $network;
+    protected ?string $network = null;
 
-    /**
-     * @var ?string
-     */
-    protected $price;
+    protected ?string $price = null;
 
-    /**
-     * @var ?string
-     */
-    protected $rate;
+    protected ?string $rate = null;
 
-    /**
-     * @var string
-     */
-    protected $status;
+    protected ?string $status = null;
 
-    /**
-     * @var ?DateTimeImmutable
-     */
-    protected $startTime;
+    protected ?DateTimeImmutable $startTime = null;
 
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $timestamp;
+    protected ?DateTimeImmutable $timestamp = null;
 
-    /**
-     * @var string
-     */
-    protected $to;
+    protected ?string $to = null;
 
-    /**
-     * @var string
-     */
-    protected $uuid;
+    protected ?string $uuid = null;
 
     /**
      * @throws Exception

--- a/src/Voice/Webhook/Factory.php
+++ b/src/Voice/Webhook/Factory.php
@@ -20,7 +20,7 @@ class Factory extends WebhookFactory
      *
      * @return mixed|Answer|Error|Event|Input|Notification|Record|Transfer
      */
-    public static function createFromArray(array $data)
+    public static function createFromArray(array $data): mixed
     {
         if (array_key_exists('status', $data)) {
             return new Event($data);

--- a/src/Voice/Webhook/Input.php
+++ b/src/Voice/Webhook/Input.php
@@ -12,40 +12,19 @@ use function json_decode;
 
 class Input
 {
-    /**
-     * @var array
-     */
-    protected $speech;
+    protected ?array $speech = null;
 
-    /**
-     * @var array
-     */
-    protected $dtmf;
+    protected ?array $dtmf = null;
 
-    /**
-     * @var string
-     */
-    protected $from;
+    protected ?string $from = null;
 
-    /**
-     * @var string
-     */
-    protected $to;
+    protected ?string $to = null;
 
-    /**
-     * @var string
-     */
-    protected $uuid;
+    protected ?string $uuid = null;
 
-    /**
-     * @var string
-     */
-    protected $conversationUuid;
+    protected ?string $conversationUuid = null;
 
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $timestamp;
+    protected ?DateTimeImmutable $timestamp = null;
 
     /**
      * @throws Exception

--- a/src/Voice/Webhook/Notification.php
+++ b/src/Voice/Webhook/Notification.php
@@ -15,17 +15,11 @@ class Notification
     /**
      * @var array<string, mixed>
      */
-    protected $payload;
+    protected ?array $payload = null;
 
-    /**
-     * @var string
-     */
-    protected $conversationUuid;
+    protected ?string $conversationUuid = null;
 
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $timestamp;
+    protected ?DateTimeImmutable $timestamp = null;
 
     /**
      * @throws Exception

--- a/src/Voice/Webhook/Record.php
+++ b/src/Voice/Webhook/Record.php
@@ -9,40 +9,19 @@ use Exception;
 
 class Record
 {
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $startTime;
+    protected ?DateTimeImmutable $startTime = null;
 
-    /**
-     * @var string
-     */
-    protected $recordingUrl;
+    protected ?string $recordingUrl = null;
 
-    /**
-     * @var int
-     */
-    protected $size;
+    protected ?int $size = null;
 
-    /**
-     * @var string
-     */
-    protected $recordingUuid;
+    protected ?string $recordingUuid = null;
 
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $endTime;
+    protected ?DateTimeImmutable $endTime = null;
 
-    /**
-     * @var string
-     */
-    protected $conversationUuid;
+    protected ?string $conversationUuid = null;
 
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $timestamp;
+    protected ?DateTimeImmutable $timestamp = null;
 
     /**
      * @throws Exception

--- a/src/Voice/Webhook/Transfer.php
+++ b/src/Voice/Webhook/Transfer.php
@@ -9,25 +9,13 @@ use Exception;
 
 class Transfer
 {
-    /**
-     * @var string
-     */
-    protected $conversationUuidFrom;
+    protected ?string $conversationUuidFrom = null;
 
-    /**
-     * @var string
-     */
-    protected $conversationUuidTo;
+    protected ?string $conversationUuidTo = null;
 
-    /**
-     * @var string
-     */
-    protected $uuid;
+    protected ?string $uuid = null;
 
-    /**
-     * @var DateTimeImmutable
-     */
-    protected $timestamp;
+    protected ?DateTimeImmutable $timestamp = null;
 
     /**
      * @throws Exception

--- a/test/Account/BalanceTest.php
+++ b/test/Account/BalanceTest.php
@@ -17,12 +17,12 @@ class BalanceTest extends VonageTestCase
 
     public function setUp(): void
     {
-        $this->balance = new Balance('12.99', false);
+        $this->balance = new Balance(12.99, false);
     }
 
     public function testObjectAccess(): void
     {
-        $this->assertEquals("12.99", $this->balance->getBalance());
+        $this->assertEquals(12.99, $this->balance->getBalance());
         $this->assertEquals(false, $this->balance->getAutoReload());
     }
 }


### PR DESCRIPTION
While this PR might look a bit big, it's just a cleanup to harden the code. This is a review of the codebase where Typehints can be introduced.

## Description
Typehints with nullsafe settings have been introduced wherever they can. While it could be regarded as a SemVer backwards breaking change, it technically is not. This is because the only way you could be calling the existing methods or properties that are not typehinted is through passing in wrong types which would result in an exception anyway.

The exception to the review is the SMS Client, which is used by Laravel and therefore will only be updated with the next major version of the SDK.

## Motivation and Context
Harden API to add standards

## How Has This Been Tested?
The test library has been key to this in that it has been run with each iteration of the code changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
