### PR TITLE
Messages API to number validation

### DIFF
--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -1243,4 +1243,50 @@ class ClientTest extends VonageTestCase
             ['caption', 'this is not valid', false]
         ];
     }
+
+    public function testWillSendValidE164Number()
+    {
+        $message = new SMSText('447700900000', '16105551212', 'Reticulating Splines');
+
+        $this->vonageClient->send(Argument::that(function (Request $request) {
+            $this->assertRequestJsonBodyContains('to', '447700900000', $request);
+            $this->assertEquals('POST', $request->getMethod());
+
+            return true;
+        }))->willReturn($this->getResponse('sms-success', 202));
+        $result = $this->messageClient->send($message);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('message_uuid', $result);
+    }
+
+    public function testWillSendValidE164NumberWithPlus()
+    {
+        $message = new SMSText('+447700900000', '16105551212', 'Reticulating Splines');
+
+        $this->vonageClient->send(Argument::that(function (Request $request) {
+            $this->assertRequestJsonBodyContains('to', '447700900000', $request);
+            $this->assertEquals('POST', $request->getMethod());
+
+            return true;
+        }))->willReturn($this->getResponse('sms-success', 202));
+        $result = $this->messageClient->send($message);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('message_uuid', $result);
+    }
+
+    public function testWillErrorOnInvalidE164Number()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $message = new SMSText('00447700900000', '16105551212', 'Reticulating Splines');
+
+        $result = $this->messageClient->send($message);
+    }
+
+    public function testWillErrorOnInvalidE164NumberWithPlus()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $message = new SMSText('+00447700900000', '16105551212', 'Reticulating Splines');
+
+        $result = $this->messageClient->send($message);
+    }
 }


### PR DESCRIPTION
This PR adds new validation for outgoing SMS messages.

## Description
There are two new parts of the validation for the Messages API client:

* Developers can now add a leading + if they want to. The SDK will automatically remove it for you before sending the request to the API
* Once the plus has been removed, a new method checks to see if it is in valid E164 format. If not, it will throw an exception before it gets to the API.

## Motivation and Context
The response from the API currently is a little bit confusing when a bad number has been sent. Rather than have the developer try and understand the response, it handles the number more gracefully in the SDK before the request is sent out.

## How Has This Been Tested?
Tests have been included in the existing suite to check the result.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
