### PR TITLE
Update WhatsAppTemplate.php

### DIFF
--- a/src/Messages/Channel/WhatsApp/WhatsAppTemplate.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppTemplate.php
@@ -34,9 +34,7 @@ class WhatsAppTemplate extends BaseMessage
             ]
         ];
 
-        if (!is_null($this->context)) {
-            $returnArray['context'] = $this->context;
-        }
+        $returnArray['context'] = $this->context ?? null;
 
         return array_merge($this->getBaseMessageUniversalOutputArray(), $returnArray);
     }


### PR DESCRIPTION
I think accessing $this->context in is_null($this->context) before initialization trigger there Typed property error. It seems to work using a coalesce operator
