### PR TITLE
Update WhatsAppSticker.php

### DIFF
--- a/src/Messages/Channel/WhatsApp/WhatsAppSticker.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppSticker.php
@@ -38,10 +38,7 @@ class WhatsAppSticker extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['sticker'] = $this->getSticker()->toArray();
-
-        if (!is_null($this->context)) {
-            $returnArray['context'] = $this->context;
-        }
+        $returnArray['context'] = $this->context ?? null;
 
         return $returnArray;
     }


### PR DESCRIPTION
I think accessing $this->context in is_null($this->context) before initialization trigger there Typed property error. It seems to work using a coalesce operator