### PR TITLE
Update WhatsAppCustom.php

### DIFF
--- a/src/Messages/Channel/WhatsApp/WhatsAppCustom.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppCustom.php
@@ -35,10 +35,7 @@ class WhatsAppCustom extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['custom'] = $this->getCustom();
-
-        if (!is_null($this->context)) {
-            $returnArray['context'] = $this->context;
-        }
+        $returnArray['context'] = $this->context ?? null;
 
         return $returnArray;
     }


### PR DESCRIPTION
I think accessing $this->context in is_null($this->context) before initialization trigger there Typed property error. It seems to work using a coalesce operator
