### PR TITLE
Update WhatsAppAudio.php

### DIFF
--- a/src/Messages/Channel/WhatsApp/WhatsAppAudio.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppAudio.php
@@ -26,10 +26,7 @@ class WhatsAppAudio extends BaseMessage
     {
         $returnArray = $this->getBaseMessageUniversalOutputArray();
         $returnArray['audio'] = $this->audioObject->toArray();
-
-        if (!is_null($this->context)) {
-            $returnArray['context'] = $this->context;
-        }
+        $returnArray['context'] = $this->context ?? null;
 
         return $returnArray;
     }


### PR DESCRIPTION
I think accessing $this->context in is_null($this->context) before initialization trigger there Typed property error. It seems to work using a coalesce operator