### PR TITLE
Added webhooks and tests for messages api

### DIFF
--- a/src/Messages/Webhook/Factory.php
+++ b/src/Messages/Webhook/Factory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vonage\Messages\Webhook;
+
+use InvalidArgumentException;
+use Vonage\Webhook\Factory as WebhookFactory;
+
+class Factory extends WebhookFactory
+{
+    protected static array $classMap = [
+        'sms' => 'Vonage\Messages\Webhook\InboundSMS',
+        'mms' => 'Vonage\Messages\Webhook\InboundMMS',
+        'rcs' => 'Vonage\Messages\Webhook\InboundRCS',
+        'whatsapp' => 'Vonage\Messages\Webhook\InboundWhatsApp',
+        'messenger' => 'Vonage\Messages\Webhook\InboundMessenger',
+        'viber_service' => 'Vonage\Messages\Webhook\InboundViber'
+    ];
+
+    public static function createFromArray(array $data): mixed
+    {
+        if (!isset($data['channel'])) {
+            throw new InvalidArgumentException("The 'channel' key is missing in the incoming data.");
+        }
+
+        $channel = $data['channel'];
+
+        if (!array_key_exists($channel, self::$classMap)) {
+            throw new InvalidArgumentException("Unable to determine incoming webhook type for channel: {$channel}");
+        }
+
+        return new self::$classMap[$channel]();
+    }
+}

--- a/src/Messages/Webhook/InboundMMS.php
+++ b/src/Messages/Webhook/InboundMMS.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vonage\Messages\Webhook;
+
+use Vonage\Entity\Hydrator\ArrayHydrateInterface;
+
+final class InboundMMS implements ArrayHydrateInterface
+{
+    protected ?array $data = null;
+
+    public function fromArray(array $data): self
+    {
+        $this->data = $data;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+
+    public function __get($name)
+    {
+        return $this->data[$name];
+    }
+}

--- a/src/Messages/Webhook/InboundMessenger.php
+++ b/src/Messages/Webhook/InboundMessenger.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vonage\Messages\Webhook;
+
+use Vonage\Entity\Hydrator\ArrayHydrateInterface;
+
+final class InboundMessenger implements ArrayHydrateInterface
+{
+    protected ?array $data = null;
+
+    public function fromArray(array $data): self
+    {
+        $this->data = $data;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+
+    public function __get($name)
+    {
+        return $this->data[$name];
+    }
+}

--- a/src/Messages/Webhook/InboundRCS.php
+++ b/src/Messages/Webhook/InboundRCS.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vonage\Messages\Webhook;
+
+use Vonage\Entity\Hydrator\ArrayHydrateInterface;
+
+final class InboundRCS implements ArrayHydrateInterface
+{
+    protected ?array $data = null;
+
+    public function fromArray(array $data): self
+    {
+        $this->data = $data;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+
+    public function __get($name)
+    {
+        return $this->data[$name];
+    }
+}

--- a/src/Messages/Webhook/InboundSMS.php
+++ b/src/Messages/Webhook/InboundSMS.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vonage\Messages\Webhook;
+
+use Vonage\Entity\Hydrator\ArrayHydrateInterface;
+
+final class InboundSMS implements ArrayHydrateInterface
+{
+    protected ?array $data = null;
+
+    public function fromArray(array $data): self
+    {
+        $this->data = $data;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+
+    public function __get($name)
+    {
+        return $this->data[$name];
+    }
+}

--- a/src/Messages/Webhook/InboundViber.php
+++ b/src/Messages/Webhook/InboundViber.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vonage\Messages\Webhook;
+
+use Vonage\Entity\Hydrator\ArrayHydrateInterface;
+
+final class InboundViber implements ArrayHydrateInterface
+{
+    protected ?array $data = null;
+
+    public function fromArray(array $data): self
+    {
+        $this->data = $data;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+
+    public function __get($name)
+    {
+        return $this->data[$name];
+    }
+}

--- a/src/Messages/Webhook/InboundWhatsApp.php
+++ b/src/Messages/Webhook/InboundWhatsApp.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vonage\Messages\Webhook;
+
+use Vonage\Entity\Hydrator\ArrayHydrateInterface;
+
+final class InboundWhatsApp implements ArrayHydrateInterface
+{
+    protected ?array $data = null;
+
+    public function fromArray(array $data): self
+    {
+        $this->data = $data;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+
+    public function __get($name)
+    {
+        return $this->data[$name];
+    }
+}

--- a/test/Messages/WebhookTest.php
+++ b/test/Messages/WebhookTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VonageTest\Messages;
+
+use Vonage\Messages\Webhook\Factory;
+use Vonage\Messages\Webhook\InboundMessenger;
+use Vonage\Messages\Webhook\InboundMMS;
+use Vonage\Messages\Webhook\InboundRCS;
+use Vonage\Messages\Webhook\InboundSMS;
+use Vonage\Messages\Webhook\InboundViber;
+use Vonage\Messages\Webhook\InboundWhatsApp;
+use VonageTest\VonageTestCase;
+
+class WebhookTest extends VonageTestCase
+{
+    public function testWillHydrateIncomingSMS(): void
+    {
+        $smsDecoded = [
+            "message_type" => "text",
+            "text" => "Hello from Vonage!",
+            "to" => "447700900000",
+            "from" => "447700900001",
+            "channel" => "sms",
+            "ttl" => 90000,
+            "sms" => [
+                "encoding_type" => "text",
+                "content_id" => "1107457532145798767",
+                "entity_id" => "1101456324675322134",
+            ],
+            "webhook_version" => "v1",
+            "client_ref" => "abc123",
+            "webhook_url" => "https://example.com/status",
+        ];
+
+        $webhook = Factory::createFromArray($smsDecoded);
+        $this->assertInstanceOf(InboundSMS::class, $webhook);
+    }
+
+    public function testWillHydrateIncomingMMSImage(): void
+    {
+        $mmsPayload = [
+            "message_type" => "image",
+            "image" => [
+                "url" => "https://example.com/image.jpg",
+                "caption" => "Additional text to accompany the image.",
+            ],
+            "to" => "447700900000",
+            "from" => "447700900001",
+            "channel" => "mms",
+            "ttl" => 600,
+            "webhook_version" => "v1",
+            "client_ref" => "abc123",
+            "webhook_url" => "https://example.com/status",
+        ];
+
+        $webhook = Factory::createFromArray($mmsPayload);
+        $this->assertInstanceOf(InboundMMS::class, $webhook);
+    }
+
+    public function testWillHydrateIncomingRCS(): void
+    {
+        $rcsPayload = [
+            "message_type" => "text",
+            "text" => "Hello from Vonage!",
+            "to" => "447700900000",
+            "from" => "Vonage",
+            "channel" => "rcs",
+            "ttl" => 600,
+            "client_ref" => "abc123",
+            "webhook_url" => "https://example.com/status",
+        ];
+
+        $webhook = Factory::createFromArray($rcsPayload);
+        $this->assertInstanceOf(InboundRCS::class, $webhook);
+    }
+
+    public function testWillHydrateIncomingMMSText(): void
+    {
+        $mmsPayload = [
+            "channel" => "mms",
+            "message_uuid" => "aaaaaaaa-bbbb-4ccc-8ddd-0123456789ab",
+            "to" => "447700900000",
+            "from" => "447700900001",
+            "timestamp" => "2020-01-01T14:00:00.000Z",
+            "origin" => ["network_code" => "12345"],
+            "message_type" => "text",
+            "text" => "This is sample text.",
+        ];
+
+        $webhook = Factory::createFromArray($mmsPayload);
+        $this->assertInstanceOf(InboundMMS::class, $webhook);
+    }
+
+    public function testWillHydrateIncomingWhatsapp(): void
+    {
+        $whatsAppPayload = [
+            "channel" => "whatsapp",
+            "message_uuid" => "aaaaaaaa-bbbb-4ccc-8ddd-0123456789ab",
+            "to" => "447700900000",
+            "from" => "447700900001",
+            "timestamp" => "2020-01-01T14:00:00.000Z",
+            "profile" => ["name" => "Jane Smith"],
+            "context_status" => "available",
+            "context" => [
+                "message_uuid" => "aaaaaaaa-bbbb-4ccc-8ddd-0123456789ab",
+                "message_from" => "447700900000",
+            ],
+            "provider_message" => "string",
+            "message_type" => "text",
+            "text" => "Hello from Vonage!",
+            "whatsapp" => [
+                "referral" => [
+                    "body" => "Check out our new product offering",
+                    "headline" => "New Products!",
+                    "source_id" => "212731241638144",
+                    "source_type" => "post",
+                    "source_url" => "https://fb.me/2ZulEu42P",
+                    "media_type" => "image",
+                    "image_url" => "https://example.com/image.jpg",
+                    "video_url" => "https://example.com/video.mp4",
+                    "thumbnail_url" => "https://example.com/thumbnail.jpg",
+                    "ctwa_clid" => "1234567890",
+                ],
+            ],
+            "_self" => [
+                "href" =>
+                    "https://api-eu.vonage.com/v1/messages/aaaaaaa-bbbb-4ccc-8ddd-0123456789ab",
+            ],
+        ];
+
+        $webhook = Factory::createFromArray($whatsAppPayload);
+        $this->assertInstanceOf(InboundWhatsApp::class, $webhook);
+    }
+
+    public function testWillHydrateIncomingMessenger(): void
+    {
+        $messengerPayload = [
+            "channel" => "messenger",
+            "message_uuid" => "aaaaaaaa-bbbb-4ccc-8ddd-0123456789ab",
+            "to" => "0123456789",
+            "from" => "9876543210",
+            "timestamp" => "2020-01-01T14:00:00.000Z",
+            "message_type" => "text",
+            "text" => "Hello from Vonage!",
+        ];
+
+        $webhook = Factory::createFromArray($messengerPayload);
+        $this->assertInstanceOf(InboundMessenger::class, $webhook);
+    }
+
+    public function testWillHydrateIncomingViberChannel(): void
+    {
+        $viberPayload = [
+            "channel" => "viber_service",
+            "context" => ["message_uuid" => "1234567890abcdef"],
+            "message_uuid" => "aaaaaaaa-bbbb-4ccc-8ddd-0123456789ab",
+            "to" => "0123456789",
+            "from" => "447700900001",
+            "timestamp" => "2020-01-01T14:00:00.000Z",
+            "message_type" => "text",
+            "text" => "Hello from Vonage!",
+        ];
+
+        $webhook = Factory::createFromArray($viberPayload);
+        $this->assertInstanceOf(InboundViber::class, $webhook);
+    }
+
+    public function testWillThrowErrorWithoutChannel(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("The 'channel' key is missing in the incoming data.");
+
+        $payload = [
+            "context" => ["message_uuid" => "1234567890abcdef"],
+            "message_uuid" => "aaaaaaaa-bbbb-4ccc-8ddd-0123456789ab",
+            "to" => "0123456789",
+            "from" => "447700900001",
+            "timestamp" => "2020-01-01T14:00:00.000Z",
+            "message_type" => "text",
+            "text" => "Hello from Vonage!",
+        ];
+
+        $webhook = Factory::createFromArray($payload);
+    }
+
+    public function testWillThrowErrorWithoutValidChannel(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Unable to determine incoming webhook type for channel: signal_service");
+
+        $payload = [
+            "channel" => "signal_service",
+            "context" => ["message_uuid" => "1234567890abcdef"],
+            "message_uuid" => "aaaaaaaa-bbbb-4ccc-8ddd-0123456789ab",
+            "to" => "0123456789",
+            "from" => "447700900001",
+            "timestamp" => "2020-01-01T14:00:00.000Z",
+            "message_type" => "text",
+            "text" => "Hello from Vonage!",
+        ];
+
+        $webhook = Factory::createFromArray($payload);
+    }
+}


### PR DESCRIPTION
This PR adds support for Webhooks in the Messages Client.

## Description
There are six possible channels that can used to hydrate a webhook. The webhook is only one per channel, not for every available type as there would be too many classes. The webhook classes act as DTOs, so have `fromArray()` and `toArray()`  which wraps a data property only with a magic getter.

The webhooks have no magic setter and are marked as final because they should be immutable.

## Motivation and Context
Missing feature.

## How Has This Been Tested?
Hydration tests have been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
