### PR TITLE
Fix docs and add nullcheck for ownedNumbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,7 +921,7 @@ $filter
     ->setPattern(234)
     ->setSearchPattern(\Vonage\Numbers\Filter\OwnedNumbers::SEARCH_PATTERN_CONTAINS)
 ;
-$response = $client->numbers()->searchOwned($filter);
+$response = $client->numbers()->searchOwned(null, $filter);
 ```
 
 `has_application`:

--- a/src/Numbers/Filter/OwnedNumbers.php
+++ b/src/Numbers/Filter/OwnedNumbers.php
@@ -38,7 +38,7 @@ class OwnedNumbers implements FilterInterface
 
     protected int $pageIndex = 1;
 
-    protected string $pattern;
+    protected ?string $pattern = null;
 
     protected int $searchPattern = 0;
 

--- a/test/Numbers/ClientTest.php
+++ b/test/Numbers/ClientTest.php
@@ -361,6 +361,27 @@ class ClientTest extends VonageTestCase
         // If there's no exception thrown, everything is fine!
     }
 
+    public function testSearchOwnedNumbersWithFilter(): void
+    {
+        $this->vonageClient->send(Argument::that(function (RequestInterface $request) {
+            $uri = $request->getUri();
+            $uriString = $uri->__toString();
+            $this->assertEquals(
+                'https://rest.nexmo.com/account/numbers?size=10&index=1&application_id=66c04cea-68b2-45e4-9061-3fd847d627b8&page_index=1',
+                $uriString
+            );
+
+            $this->assertEquals('GET', $request->getMethod());
+
+            return true;
+        }))->willReturn($this->getResponse('owned-numbers'));
+
+        $filter = new \Vonage\Numbers\Filter\OwnedNumbers();
+        $filter->setApplicationId("66c04cea-68b2-45e4-9061-3fd847d627b8");
+
+        $response = $this->numberClient->searchOwned(null, $filter);
+    }
+
     public function testPurchaseNumberWithNumberAndCountry(): void
     {
         // When providing a number string, the first thing that happens is a GET request to fetch number details

--- a/test/Numbers/responses/owned-numbers.json
+++ b/test/Numbers/responses/owned-numbers.json
@@ -1,0 +1,16 @@
+{
+  "count": 1234,
+  "numbers": [
+    {
+      "country": "GB",
+      "msisdn": "447700900000",
+      "type": "mobile-lvn",
+      "cost": "1.25",
+      "features": [
+        "VOICE",
+        "SMS",
+        "MMS"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This fixes the documentation and adds a null check for adding a pattern to an OwnedNumbers filter.

## Description
Added a new test to cover what is included in the docs for searching your own numbers in the Numbers API.

## Motivation and Context
Bug fix.

## How Has This Been Tested?
Test added.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
