### PR TITLE
Added ability to add a fallback URL on application

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,9 @@
     <testsuite name="verify">
       <directory>test/Verify</directory>
     </testsuite>
+    <testsuite name="application">
+      <directory>test/Application</directory>
+    </testsuite>
     <testsuite name="verify2">
       <directory>test/Verify2</directory>
     </testsuite>

--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -230,7 +230,7 @@ class Application implements EntityInterface, JsonSerializable, ArrayHydrateInte
     {
         // Build up capabilities that are set
         $availableCapabilities = [
-            'voice' => [VoiceConfig::ANSWER, VoiceConfig::EVENT],
+            'voice' => [VoiceConfig::ANSWER, VoiceConfig::EVENT, VoiceConfig::FALLBACK_ANSWER_URL],
             'messages' => [MessagesConfig::INBOUND, MessagesConfig::STATUS],
             'rtc' => [RtcConfig::EVENT]
         ];

--- a/src/Application/VoiceConfig.php
+++ b/src/Application/VoiceConfig.php
@@ -10,6 +10,8 @@ class VoiceConfig
 {
     public const EVENT = 'event_url';
     public const ANSWER = 'answer_url';
+    public const FALLBACK_ANSWER_URL = 'fallback_answer_url';
+
     protected ?bool $signedCallbacks = null;
     protected ?int $conversationsTtl = null;
     protected ?string $region = null;

--- a/src/Application/Webhook.php
+++ b/src/Application/Webhook.php
@@ -8,9 +8,7 @@ class Webhook implements \Stringable
 {
     public const METHOD_POST = 'POST';
     public const METHOD_GET = 'GET';
-
     public ?string $socketTimeout = null;
-
     public ?string $connectionTimeout = null;
 
     public function __construct(protected ?string $url, protected ?string $method = self::METHOD_POST)

--- a/test/Application/ApplicationTest.php
+++ b/test/Application/ApplicationTest.php
@@ -9,6 +9,7 @@ use Vonage\Application\Application;
 use Vonage\Application\MessagesConfig;
 use Vonage\Application\RtcConfig;
 use Vonage\Application\VoiceConfig;
+use Vonage\Application\Webhook;
 use Vonage\Client\Exception\Exception as ClientException;
 use VonageTest\Traits\HTTPTestTrait;
 use VonageTest\VonageTestCase;
@@ -163,5 +164,18 @@ class ApplicationTest extends VonageTestCase
 
         $webhook = $otherapp->getVoiceConfig()->getWebhook(VoiceConfig::ANSWER);
         $this->assertEquals('https://example.com/webhooks/answer', $webhook);
+    }
+
+    public function testCanSetFallbackUrlWebhook(): void
+    {
+        $application = new Application();
+        $application->setName('my application');
+        $application->getVoiceConfig()->setRegion('eu-west');
+
+        $webhook = new Webhook('https://example.com/fallbackUrl', 'GET');
+        $application->getVoiceConfig()->setWebhook(\Vonage\Application\VoiceConfig::FALLBACK_ANSWER_URL, $webhook);
+
+        $output = $application->toArray();
+        $this->assertEquals('https://example.com/fallbackUrl', $output['capabilities']['voice']['webhooks']['fallback_answer_url']['address']);
     }
 }

--- a/test/Application/ClientTest.php
+++ b/test/Application/ClientTest.php
@@ -556,17 +556,4 @@ class ClientTest extends VonageTestCase
         $application->setName('my application');
         $application->getVoiceConfig()->setRegion('eu-west-1');
     }
-
-    public function testCanSetFallbackUrlWebhook(): void
-    {
-        $application = new Application();
-        $application->setName('my application');
-        $application->getVoiceConfig()->setRegion('eu-west');
-
-        $webhook = new Webhook('https://example.com/fallbackUrl', 'GET');
-        $application->getVoiceConfig()->setWebhook(\Vonage\Application\VoiceConfig::FALLBACK_ANSWER_URL, $webhook);
-
-        $output = $application->toArray();
-        $this->assertEquals('https://example.com/fallbackUrl', $output['capabilities']['voice']['webhooks']['fallback_answer_url']['address']);
-    }
 }

--- a/test/Application/ClientTest.php
+++ b/test/Application/ClientTest.php
@@ -556,4 +556,17 @@ class ClientTest extends VonageTestCase
         $application->setName('my application');
         $application->getVoiceConfig()->setRegion('eu-west-1');
     }
+
+    public function testCanSetFallbackUrlWebhook(): void
+    {
+        $application = new Application();
+        $application->setName('my application');
+        $application->getVoiceConfig()->setRegion('eu-west');
+
+        $webhook = new Webhook('https://example.com/fallbackUrl', 'GET');
+        $application->getVoiceConfig()->setWebhook(\Vonage\Application\VoiceConfig::FALLBACK_ANSWER_URL, $webhook);
+
+        $output = $application->toArray();
+        $this->assertEquals('https://example.com/fallbackUrl', $output['capabilities']['voice']['webhooks']['fallback_answer_url']['address']);
+    }
 }


### PR DESCRIPTION
Currently the application entity does not allow you a create a fallback answer URL. This adds the constant to allow that ability.

## Description
Application webhooks now have a constant added to them to allow to create this type of webhook when creating or updating an application. Here is an example:

```
        $application = new Application();
        $application->setName('my application');
        $webhook = new Webhook('https://example.com/fallbackUrl', 'GET');
        $application->getVoiceConfig()->setWebhook(\Vonage\Application\VoiceConfig::FALLBACK_ANSWER_URL, $webhook);
```

## Motivation and Context
Reported in #289 

## How Has This Been Tested?
Added a test to check the output

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
