### PR TITLE
Added validation logic for e164

### DIFF
--- a/src/Messages/Channel/MMS/MMSAudio.php
+++ b/src/Messages/Channel/MMS/MMSAudio.php
@@ -12,6 +12,7 @@ class MMSAudio extends BaseMessage
 
     protected string $channel = 'mms';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_AUDIO;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -20,6 +21,11 @@ class MMSAudio extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/MMS/MMSImage.php
+++ b/src/Messages/Channel/MMS/MMSImage.php
@@ -12,6 +12,7 @@ class MMSImage extends BaseMessage
 
     protected string $channel = 'mms';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_IMAGE;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -20,6 +21,11 @@ class MMSImage extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/MMS/MMSVideo.php
+++ b/src/Messages/Channel/MMS/MMSVideo.php
@@ -13,6 +13,7 @@ class MMSVideo extends BaseMessage
 
     protected string $channel = 'mms';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VIDEO;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -21,6 +22,11 @@ class MMSVideo extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/MMS/MMSvCard.php
+++ b/src/Messages/Channel/MMS/MMSvCard.php
@@ -12,6 +12,7 @@ class MMSvCard extends BaseMessage
 
     protected string $channel = 'mms';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VCARD;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -20,6 +21,11 @@ class MMSvCard extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/Message.php
+++ b/src/Messages/Channel/Message.php
@@ -19,6 +19,7 @@ interface Message
     public function setWebhookUrl(string $url): void;
     public function getWebhookVersion(): ?string;
     public function setWebhookVersion(string $version): void;
+    public function validatesE164(): bool;
 
     /**
      * All message types have shared outputs required by the endpoint.

--- a/src/Messages/Channel/Messenger/MessengerAudio.php
+++ b/src/Messages/Channel/Messenger/MessengerAudio.php
@@ -11,6 +11,7 @@ class MessengerAudio extends BaseMessage
 
     protected string $channel = 'messenger';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_AUDIO;
+    protected bool $validatesE164 = false;
 
     public function __construct(
         string $to,
@@ -23,6 +24,11 @@ class MessengerAudio extends BaseMessage
         $this->from = $from;
         $this->category = $category;
         $this->tag = $tag;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/Messenger/MessengerFile.php
+++ b/src/Messages/Channel/Messenger/MessengerFile.php
@@ -11,6 +11,7 @@ class MessengerFile extends BaseMessage
 
     protected string $channel = 'messenger';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_FILE;
+    protected bool $validatesE164 = false;
 
     public function __construct(
         string $to,
@@ -35,5 +36,10 @@ class MessengerFile extends BaseMessage
         }
 
         return $returnArray;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 }

--- a/src/Messages/Channel/Messenger/MessengerImage.php
+++ b/src/Messages/Channel/Messenger/MessengerImage.php
@@ -11,6 +11,7 @@ class MessengerImage extends BaseMessage
 
     protected string $channel = 'messenger';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_IMAGE;
+    protected bool $validatesE164 = false;
 
     public function __construct(
         string $to,
@@ -35,5 +36,10 @@ class MessengerImage extends BaseMessage
         }
 
         return $returnArray;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 }

--- a/src/Messages/Channel/Messenger/MessengerObjectTrait.php
+++ b/src/Messages/Channel/Messenger/MessengerObjectTrait.php
@@ -7,14 +7,10 @@ trait MessengerObjectTrait
     private ?string $category;
     private ?string $tag;
 
-    /**
-     * @return string
-     */
     public function getCategory(): ?string
     {
         return $this->category;
     }
-
 
     public function requiresMessengerObject(): bool
     {
@@ -26,9 +22,6 @@ trait MessengerObjectTrait
         $this->category = $category;
     }
 
-    /**
-     * @return string
-     */
     public function getTag(): ?string
     {
         return $this->tag;

--- a/src/Messages/Channel/Messenger/MessengerText.php
+++ b/src/Messages/Channel/Messenger/MessengerText.php
@@ -12,6 +12,7 @@ class MessengerText extends BaseMessage
 
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_TEXT;
     protected string $channel = 'messenger';
+    protected bool $validatesE164 = false;
 
     public function __construct(
         string $to,
@@ -25,6 +26,11 @@ class MessengerText extends BaseMessage
         $this->text = $text;
         $this->category = $category;
         $this->tag = $tag;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/Messenger/MessengerVideo.php
+++ b/src/Messages/Channel/Messenger/MessengerVideo.php
@@ -11,6 +11,7 @@ class MessengerVideo extends BaseMessage
 
     protected string $channel = 'messenger';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VIDEO;
+    protected bool $validatesE164 = false;
 
     public function __construct(
         string $to,
@@ -23,6 +24,11 @@ class MessengerVideo extends BaseMessage
         $this->from = $from;
         $this->category = $category;
         $this->tag = $tag;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/RCS/RcsCustom.php
+++ b/src/Messages/Channel/RCS/RcsCustom.php
@@ -16,6 +16,7 @@ class RcsCustom extends BaseMessage
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_FILE;
     protected string $channel = 'rcs';
     protected array $custom;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -25,6 +26,11 @@ class RcsCustom extends BaseMessage
         $this->to = $to;
         $this->from = $from;
         $this->custom = $custom;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function getCustom(): array

--- a/src/Messages/Channel/RCS/RcsFile.php
+++ b/src/Messages/Channel/RCS/RcsFile.php
@@ -16,6 +16,7 @@ class RcsFile extends BaseMessage
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_FILE;
     protected string $channel = 'rcs';
     protected FileObject $file;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -25,6 +26,11 @@ class RcsFile extends BaseMessage
         $this->to = $to;
         $this->from = $from;
         $this->file = $file;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function setTtl(?int $ttl): void

--- a/src/Messages/Channel/RCS/RcsImage.php
+++ b/src/Messages/Channel/RCS/RcsImage.php
@@ -16,6 +16,7 @@ class RcsImage extends BaseMessage
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_IMAGE;
     protected string $channel = 'rcs';
     protected ImageObject $image;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -25,6 +26,11 @@ class RcsImage extends BaseMessage
         $this->to = $to;
         $this->from = $from;
         $this->image = $image;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function setTtl(?int $ttl): void

--- a/src/Messages/Channel/RCS/RcsText.php
+++ b/src/Messages/Channel/RCS/RcsText.php
@@ -16,6 +16,7 @@ class RcsText extends BaseMessage
 
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_TEXT;
     protected string $channel = 'rcs';
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -25,6 +26,11 @@ class RcsText extends BaseMessage
         $this->to = $to;
         $this->from = $from;
         $this->text = $message;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function setTtl(?int $ttl): void

--- a/src/Messages/Channel/RCS/RcsVideo.php
+++ b/src/Messages/Channel/RCS/RcsVideo.php
@@ -16,6 +16,7 @@ class RcsVideo extends BaseMessage
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VIDEO;
     protected string $channel = 'rcs';
     protected VideoObject $video;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -25,6 +26,11 @@ class RcsVideo extends BaseMessage
         $this->to = $to;
         $this->from = $from;
         $this->video = $videoObject;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function setTtl(?int $ttl): void

--- a/src/Messages/Channel/SMS/SMSText.php
+++ b/src/Messages/Channel/SMS/SMSText.php
@@ -21,6 +21,7 @@ class SMSText extends BaseMessage
     protected ?string $encodingType = null;
     protected ?string $contentId = null;
     protected ?string $entityId = null;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -30,6 +31,11 @@ class SMSText extends BaseMessage
         $this->to = $to;
         $this->from = $from;
         $this->text = $message;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function getEncodingType(): ?string

--- a/src/Messages/Channel/Viber/ViberFile.php
+++ b/src/Messages/Channel/Viber/ViberFile.php
@@ -11,6 +11,7 @@ class ViberFile extends BaseMessage
 
     protected string $channel = 'viber_service';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_FILE;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -19,6 +20,11 @@ class ViberFile extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/Viber/ViberImage.php
+++ b/src/Messages/Channel/Viber/ViberImage.php
@@ -12,6 +12,7 @@ class ViberImage extends BaseMessage
 
     protected string $channel = 'viber_service';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_IMAGE;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -28,6 +29,11 @@ class ViberImage extends BaseMessage
         $this->ttl = $ttl;
         $this->type = $type;
         $this->action = $viberActionObject;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/Viber/ViberText.php
+++ b/src/Messages/Channel/Viber/ViberText.php
@@ -13,6 +13,7 @@ class ViberText extends BaseMessage
 
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_TEXT;
     protected string $channel = 'viber_service';
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -30,6 +31,11 @@ class ViberText extends BaseMessage
         $this->ttl = $ttl;
         $this->type = $type;
         $this->action = $viberActionObject;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/Viber/ViberVideo.php
+++ b/src/Messages/Channel/Viber/ViberVideo.php
@@ -13,6 +13,7 @@ class ViberVideo extends BaseMessage
 
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VIDEO;
     protected string $channel = 'viber_service';
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -26,6 +27,11 @@ class ViberVideo extends BaseMessage
         $this->duration = $duration;
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/WhatsApp/WhatsAppAudio.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppAudio.php
@@ -12,6 +12,7 @@ class WhatsAppAudio extends BaseMessage
 
     protected string $channel = 'whatsapp';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_AUDIO;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -20,6 +21,11 @@ class WhatsAppAudio extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/WhatsApp/WhatsAppCustom.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppCustom.php
@@ -11,6 +11,7 @@ class WhatsAppCustom extends BaseMessage
 
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_CUSTOM;
     protected string $channel = 'whatsapp';
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -19,6 +20,11 @@ class WhatsAppCustom extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function setCustom(array $custom): void

--- a/src/Messages/Channel/WhatsApp/WhatsAppFile.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppFile.php
@@ -12,6 +12,7 @@ class WhatsAppFile extends BaseMessage
 
     protected string $channel = 'whatsapp';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_FILE;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -20,6 +21,11 @@ class WhatsAppFile extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/WhatsApp/WhatsAppImage.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppImage.php
@@ -12,6 +12,7 @@ class WhatsAppImage extends BaseMessage
 
     protected string $channel = 'whatsapp';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_IMAGE;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -20,6 +21,11 @@ class WhatsAppImage extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/WhatsApp/WhatsAppSticker.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppSticker.php
@@ -12,6 +12,7 @@ class WhatsAppSticker extends BaseMessage
 
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_STICKER;
     protected string $channel = 'whatsapp';
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -20,6 +21,11 @@ class WhatsAppSticker extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function getSticker(): StickerObject

--- a/src/Messages/Channel/WhatsApp/WhatsAppTemplate.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppTemplate.php
@@ -13,6 +13,7 @@ class WhatsAppTemplate extends BaseMessage
 
     protected string $channel = 'whatsapp';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_TEMPLATE;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -22,6 +23,11 @@ class WhatsAppTemplate extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/WhatsApp/WhatsAppText.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppText.php
@@ -13,6 +13,7 @@ class WhatsAppText extends BaseMessage
 
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_TEXT;
     protected string $channel = 'whatsapp';
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -22,6 +23,11 @@ class WhatsAppText extends BaseMessage
         $this->to = $to;
         $this->from = $from;
         $this->text = $text;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Channel/WhatsApp/WhatsAppVideo.php
+++ b/src/Messages/Channel/WhatsApp/WhatsAppVideo.php
@@ -12,6 +12,7 @@ class WhatsAppVideo extends BaseMessage
 
     protected string $channel = 'whatsapp';
     protected string $subType = BaseMessage::MESSAGES_SUBTYPE_VIDEO;
+    protected bool $validatesE164 = true;
 
     public function __construct(
         string $to,
@@ -20,6 +21,11 @@ class WhatsAppVideo extends BaseMessage
     ) {
         $this->to = $to;
         $this->from = $from;
+    }
+
+    public function validatesE164(): bool
+    {
+        return $this->validatesE164;
     }
 
     public function toArray(): array

--- a/src/Messages/Client.php
+++ b/src/Messages/Client.php
@@ -25,12 +25,16 @@ class Client implements APIClient
     {
         $messageArray = $message->toArray();
 
-        if ($this->isValidE164($messageArray['to'])) {
-            $messageArray['to'] = $this->stripLeadingPlus($messageArray['to']);
-            return $this->getAPIResource()->create($messageArray);
-        };
+        if ($message->validatesE164()) {
+            if ($this->isValidE164($messageArray['to'])) {
+                $messageArray['to'] = $this->stripLeadingPlus($messageArray['to']);
+                return $this->getAPIResource()->create($messageArray);
+            } else {
+                throw new \InvalidArgumentException('Number provided is not a valid E164 number');
+            }
+        }
 
-        throw new \InvalidArgumentException('Number provided is not a valid E164 number');
+        return $this->getAPIResource()->create($messageArray);
     }
 
     public function updateRcsStatus(string $messageUuid, string $status): bool

--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -572,7 +572,7 @@ class ClientTest extends VonageTestCase
     public function testCanSendMessengerText(): void
     {
         $payload = [
-            'to' => '447700900000',
+            'to' => '10152368852405295',
             'from' => '16105551212',
             'text' => 'This is a messenger response',
             'category' => 'response'


### PR DESCRIPTION
Not all message objects for the messages API use E164 validation.

## Description
Facebook Messenger uses an ID. So, a new signature has been added to the interface for BaseMessage.
This is an internal change to validate something that would have triggered an error from the API anyway, and previously Messenger objects would not be sent. This is therefore not a breaking change but a bug fix.

## Motivation and Context
Fixes #520 

## How Has This Been Tested?
The existing test suite needs to pass to show validation working when it needs to. Messenger test has been adjusted.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
