### PR TITLE
Fixed captions on whatsapp audio

### DIFF
--- a/src/Messages/MessageObjects/AudioObject.php
+++ b/src/Messages/MessageObjects/AudioObject.php
@@ -6,7 +6,10 @@ use Vonage\Entity\Hydrator\ArrayHydrateInterface;
 
 class AudioObject implements ArrayHydrateInterface
 {
-    public function __construct(private string $url, private string $caption = '')
+    /**
+     * Legacy to pass in a caption as this should never have been supported. Nothing will happen if you pass one in.
+     */
+    public function __construct(private string $url, private readonly ?string $caption = null)
     {
     }
 
@@ -14,26 +17,14 @@ class AudioObject implements ArrayHydrateInterface
     {
         $this->url = $data['url'];
 
-        if (isset($data['caption'])) {
-            $this->caption = $data['caption'];
-        }
-
         return $this;
     }
 
     public function toArray(): array
     {
-        $returnArray = [
+        return [
             'url' => $this->url
         ];
-
-        if ($this->caption) {
-            $returnArray[] = [
-                'caption' => $this->caption
-            ];
-        }
-
-        return $returnArray;
     }
 
     public function getUrl(): string
@@ -41,8 +32,17 @@ class AudioObject implements ArrayHydrateInterface
         return $this->url;
     }
 
+    /**
+     * @deprecated Unsupported
+     * @return string
+     */
     public function getCaption(): string
     {
+        trigger_error(
+            'Captions are not supported in this API, this will error at server level.',
+            E_USER_DEPRECATED
+        );
+
         return $this->caption;
     }
 }

--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -376,7 +376,7 @@ class ClientTest extends VonageTestCase
     {
         $audioObject = new AudioObject(
             'https://file-examples.com/wp-content/uploads/2017/11/file_example_MP3_700KB.mp3',
-            'some audio'
+            null
         );
 
         $payload = [


### PR DESCRIPTION
This PR removes the ability to add a caption to a WhatsAppAudio Object.

## Description
Captions are not supported on the API, so this shouldn't have been an available feature. Nothing will get rendered if you pass a caption in, though it will now throw a warning.

## How Has This Been Tested?
Tests have been adjusted accordingly.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
