### PR TITLE
Added constant to extract voiceStatusCallbackUrl

### DIFF
--- a/src/Numbers/Number.php
+++ b/src/Numbers/Number.php
@@ -43,6 +43,7 @@ class Number implements EntityInterface, JsonSerializableInterface, JsonUnserial
 
     public const WEBHOOK_MESSAGE = 'moHttpUrl';
     public const WEBHOOK_VOICE_STATUS = 'voiceStatusCallback';
+    public const WEBHOOK_VOICE_STATUS_URL = 'voiceStatusCallbackUrl';
 
     public const ENDPOINT_SIP = 'sip';
     public const ENDPOINT_TEL = 'tel';


### PR DESCRIPTION
This PR adds the ability to extract the voiceStatusCallbackUrl by calling `getWebhook(Number::WEBHOOK_STATUS_CALLBACK_URL)`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
