### PR TITLE
Add Method to mark WhatsApp Message

### DIFF
--- a/src/Messages/Client.php
+++ b/src/Messages/Client.php
@@ -11,6 +11,7 @@ use Vonage\Messages\Channel\BaseMessage;
 class Client implements APIClient
 {
     public const RCS_STATUS_REVOKED = 'revoked';
+    public const WHATSAPP_STATUS_READ = 'read';
 
     public function __construct(protected APIResource $api)
     {
@@ -45,7 +46,15 @@ class Client implements APIClient
         } catch (\Exception $e) {
             return false;
         }
-        return false;
+    }
+
+    /**
+     * This method is just a wrapper for updateRcsStatus to make it semantically
+     * correct for other uses such as WhatsApp messages
+     */
+    public function markAsStatus(string $messageUuid, string $status): bool
+    {
+        return $this->updateRcsStatus($messageUuid, $status);
     }
 
     protected function stripLeadingPlus(string $phoneNumber): string

--- a/test/Messages/ClientTest.php
+++ b/test/Messages/ClientTest.php
@@ -1235,6 +1235,30 @@ class ClientTest extends VonageTestCase
         $this->messageClient->updateRcsStatus('6ce72c29-e454-442a-94f2-47a1cadba45f', MessagesClient::RCS_STATUS_REVOKED);
     }
 
+    public function testCanUpdateWhatsAppStatus(): void
+    {
+        $geoSpecificClient = clone $this->messageClient;
+        $geoSpecificClient->getAPIResource()->setBaseUrl('https://api-us.nexmo.com/v1');
+
+        $this->vonageClient->send(Argument::that(function (Request $request) {
+            $this->assertEquals(
+                'Bearer ',
+                mb_substr($request->getHeaders()['Authorization'][0], 0, 7)
+            );
+            $uri = $request->getUri();
+            $uriString = $uri->__toString();
+            $this->assertEquals('https://api-us.nexmo.com/v1/messages/6ce72c29-e454-442a-94f2-47a1cadba45f',
+                $uriString);
+
+            $this->assertRequestJsonBodyContains('status', 'read', $request);
+            $this->assertEquals('PATCH', $request->getMethod());
+
+            return true;
+        }))->willReturn($this->getResponse('rcs-update-success'));
+
+        $geoSpecificClient->markAsStatus('6ce72c29-e454-442a-94f2-47a1cadba45f', MessagesClient::WHATSAPP_STATUS_READ);
+    }
+
     public function stickerTypeProvider(): array
     {
         return [


### PR DESCRIPTION
The SDK is currently missing a method to mark a WhatsApp message as read.

## Description
Using the Messages Client, you can now use `markAsStatus()`

## Motivation and Context
There is some important context here, in that *just* using the method will return an API error. This is because the developer needs to specify the region, which is done by editing the `APIResource` object. Thus, a live example call would be:

```
$client->messages()->getApiResource()->setBaseUrl('https://api-eu.nexmo.com/v1');
$client->messages()->markAsStatus('message_uuid', MessageClient::WHATSAPP_STATUS_READ);
```

## How Has This Been Tested?
Test added to make sure the output is correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
