### PR TITLE
added method to delete member in conversations client

### DIFF
--- a/src/Conversation/Client.php
+++ b/src/Conversation/Client.php
@@ -152,6 +152,13 @@ class Client implements APIClient
         return $member;
     }
 
+    public function deleteMember(string $memberId, string $conversationId): bool
+    {
+        $this->getApiResource()->delete($conversationId . '/members/' . $memberId);
+
+        return true;
+    }
+
     public function createEvent(EventRequest $event): Event
     {
         $response = $this->getAPIResource()->create($event->toArray(), '/' . $event->getConversationId() . '/events');

--- a/test/Conversation/ClientTest.php
+++ b/test/Conversation/ClientTest.php
@@ -809,6 +809,29 @@ class ClientTest extends VonageTestCase
         $this->assertInstanceOf(Member::class, $response);
     }
 
+    public function testWillDeleteMemberInConversation(): void
+    {
+        $this->vonageClient->send(Argument::that(function (Request $request) use (&$requestIndex) {
+            $this->assertEquals('DELETE', $request->getMethod());
+
+            $uri = $request->getUri();
+            $uriString = $uri->__toString();
+
+            $this->assertEquals(
+                'https://api.nexmo.com/v1/conversations/CON-d66d47de-5bcb-4300-94f0-0c9d4b948e9a/members/' .
+                'MEM-63f61863-4a51-4f6b-86e1-46edebio0391',
+                $uriString
+            );
+
+            return true;
+        }))->willReturn($this->getResponse('delete-member', 204));
+
+        $this->conversationsClient->deleteMember(
+            'MEM-63f61863-4a51-4f6b-86e1-46edebio0391',
+            'CON-d66d47de-5bcb-4300-94f0-0c9d4b948e9a'
+        );
+    }
+
     public function testWillCreateEvent(): void
     {
         $messageText = new EventRequest(


### PR DESCRIPTION
This PR adds the delete method for a member in a conversation.

## Description
Call `$client->conversation()->deleteMember(CONVERSATION_ID, MEMBER_ID);` to use

## Motivation and Context
Missing methods

## How Has This Been Tested?
Test added to cover completion.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
