### PR TITLE
Move NI and Verify to Basic

### DIFF
--- a/src/Insights/ClientFactory.php
+++ b/src/Insights/ClientFactory.php
@@ -6,6 +6,7 @@ namespace Vonage\Insights;
 
 use Psr\Container\ContainerInterface;
 use Vonage\Client\APIResource;
+use Vonage\Client\Credentials\Handler\BasicHandler;
 use Vonage\Client\Credentials\Handler\BasicQueryHandler;
 
 class ClientFactory
@@ -15,7 +16,7 @@ class ClientFactory
         /** @var APIResource $api */
         $api = $container->make(APIResource::class);
         $api->setIsHAL(false);
-        $api->setAuthHandlers(new BasicQueryHandler());
+        $api->setAuthHandlers(new BasicHandler());
 
         return new Client($api);
     }

--- a/src/Verify/ClientFactory.php
+++ b/src/Verify/ClientFactory.php
@@ -6,6 +6,7 @@ namespace Vonage\Verify;
 
 use Psr\Container\ContainerInterface;
 use Vonage\Client\APIResource;
+use Vonage\Client\Credentials\Handler\BasicHandler;
 use Vonage\Client\Credentials\Handler\TokenBodyHandler;
 
 class ClientFactory
@@ -18,7 +19,7 @@ class ClientFactory
             ->setIsHAL(false)
             ->setBaseUri('/verify')
             ->setErrorsOn200(true)
-            ->setAuthHandlers(new TokenBodyHandler())
+            ->setAuthHandlers(new BasicHandler())
             ->setExceptionErrorHandler(new ExceptionErrorHandler());
 
         return new Client($api);

--- a/test/Insights/ClientTest.php
+++ b/test/Insights/ClientTest.php
@@ -52,6 +52,7 @@ class ClientTest extends VonageTestCase
         $this->api = new APIResource();
         $this->api->setIsHAL(false);
         $this->api->setClient($this->vonageClient->reveal());
+        $this->api->setAuthHandlers(new Client\Credentials\Handler\BasicHandler());
 
         $this->insightsClient = new InsightsClient($this->api);
     }

--- a/test/Verify/ClientTest.php
+++ b/test/Verify/ClientTest.php
@@ -51,22 +51,23 @@ class ClientTest extends VonageTestCase
             ->setIsHAL(false)
             ->setBaseUri('/verify')
             ->setErrorsOn200(true)
-            ->setAuthHandlers(new Client\Credentials\Handler\TokenBodyHandler())
+            ->setAuthHandlers(new Client\Credentials\Handler\BasicHandler())
             ->setClient($this->vonageClient->reveal())
             ->setExceptionErrorHandler(new ExceptionErrorHandler());
 
         $this->client = new VerifyClient($api);
     }
 
-    public function testUsesCorrectAuthInBody(): void
+    public function testUsesCorrectAuth(): void
     {
         $this->vonageClient->send(
             Argument::that(
                 function (RequestInterface $request) {
-                    $this->assertRequestJsonBodyContains('api_key', 'abc', $request);
-                    $this->assertRequestJsonBodyContains('api_secret', 'def', $request);
                     $this->assertRequestMatchesUrl('https://api.nexmo.com/verify/psd2/json', $request);
-
+                    $this->assertEquals(
+                        'Basic ',
+                        mb_substr($request->getHeaders()['Authorization'][0], 0, 6)
+                    );
                     return true;
                 }
             )


### PR DESCRIPTION
This PR internally changes Number Insight and Verify (legacy) to use Basic header authorization for security.

## Description
Because this is an internal change that has no effect on users giving Basic credentials, there is no SemVer major bump.

## Motivation and Context
Changes in API Security at Vonage.

## How Has This Been Tested?
Tests adjusted to reflect sending the correct header.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
