### PR TITLE
fix: use `setBaseUri` for `Verify2/ClientFactory`

### DIFF
--- a/src/Verify2/ClientFactory.php
+++ b/src/Verify2/ClientFactory.php
@@ -15,7 +15,7 @@ class ClientFactory
         $api->setIsHAL(false)
             ->setErrorsOn200(false)
             ->setAuthHandlers([new KeypairHandler(), new BasicHandler()])
-            ->setBaseUrl('https://api.nexmo.com/v2/verify');
+            ->setBaseUri('/v2/verify');
 
         return new Client($api);
     }

--- a/test/Verify2/ClientFactoryTest.php
+++ b/test/Verify2/ClientFactoryTest.php
@@ -20,6 +20,7 @@ class ClientFactoryTest extends TestCase
         ];
 
         $mockClient = $this->createMock(Client::class);
+        $mockClient->method('getApiUrl')->willReturn('https://api.nexmo.com');
         $container = new MapFactory($mockServices, $mockClient);
         $factory = new ClientFactory();
 
@@ -29,7 +30,8 @@ class ClientFactoryTest extends TestCase
             ->getAuthHandlers()[0]);
         $this->assertInstanceOf(Client\Credentials\Handler\BasicHandler::class, $result->getAPIResource()
             ->getAuthHandlers()[1]);
-        $this->assertEquals('https://api.nexmo.com/v2/verify', $result->getAPIResource()->getBaseUrl());
+        $this->assertEquals('https://api.nexmo.com', $result->getAPIResource()->getBaseUrl());
+        $this->assertEquals('/v2/verify', $result->getAPIResource()->getBaseUri());
         $this->assertFalse($result->getApiResource()->errorsOn200());
         $this->assertFalse($result->getApiResource()->isHAL());
     }


### PR DESCRIPTION
## Description
using `setBaseUri` for `Verify2/ClientFactory` instead of `setBaseUrl`

## Motivation and Context
My Test-Setup with an PSR-18 Client will fail because it uses the Live-API for this request.
```php
$client = new Vonage\Client(
    new Vonage\Client\Credentials\Basic(API_KEY, API_SECRET),
    [
        'base_api_url' => 'https://example.com'
    ],
    $myPSR18Client
);
// still on https://api.nexmo.com
$client->verify2()->startVerification(/* ... */);
```

## How Has This Been Tested?
```php
$myPSR18Client->method('sendRequest')->with(self::callback(static function(RequestInterface $request) {
  self::assertSame('https://example.com/v2/verify', $request->getUri()->__toString()
  return true;
}));
$client->verify2()->startVerification(/* ... */);
```

## Example Output or Screenshots (if appropriate):

Expect that the Method will respect the `base_api_url`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
